### PR TITLE
wip: add vsphere client controller logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,48 @@ If a release is deleted, the `NodeImage` Status is updated to remove the release
 If a `NodeImage` is no longer needed, it is deleted.
 
 ### `image-controller`
-TODO
+The `image-controller` watches `NodeImage` custom resources on the workload clusters.
+For each `NodeImage` that is created, it will ensure that the image is available inside the provider image catalog.
+The current state of the image is stored in the `NodeImage` Status. (e.g. `Available`, `Uploading`)
+If the image is not available, the controller will attempt to upload the image to the provider image catalogs.
+If the image is available, the controller will update the `NodeImage` Status to `Available`.
+If the `NodeImage` is deleted, the controller will remove the image from the provider image catalogs.
+
+### AWS S3 Client
+The `image-controller` imports images from a public S3 bucket.
+The bucket is specified inside the `values.yaml` file.
+
+```yaml
+s3:
+  bucket: "my-bucket"
+  region: "us-west-2"
+```
+
+### Vsphere Client
+The `image-controller` can upload images to one or more locations inside a VCenter.
+The VCenter credentials and locations are specified inside the `values.yaml` file.
+
+```yaml
+vsphere:
+  credentials:
+    username: "my-username"
+    password: "my-password"
+    vcenter: "my-vcenter"
+  locations:
+    location1:
+      datacenter: "my-datacenter"
+      datastore: "my-datastore"
+      cluster: "my-cluster"
+      folder: "my-folder"
+    location2:
+      datacenter: "another-datacenter"
+      datastore: "another-datastore"
+      cluster: "another-cluster"
+      folder: "another-folder"
+      resourcepool: "my-resourcepool" # Optional
+      host: "my-host" # Optional
+      network: "my-network" # Optional
+```
 
 ## Getting Started
 

--- a/api/image/v1alpha1/nodeimage_types.go
+++ b/api/image/v1alpha1/nodeimage_types.go
@@ -38,13 +38,13 @@ type NodeImageSpec struct {
 type NodeImageState string
 
 const (
-	NodeImagePending    NodeImageState = "Pending"
-	NodeImageUploading  NodeImageState = "Uploading"
-	NodeImageAvailable  NodeImageState = "Available"
-	NodeImageError      NodeImageState = "Error"
-	NodeImageDeleting   NodeImageState = "Deleting"
-	NodeImageDeleted    NodeImageState = "Deleted"
-	NodeImageDeprecated NodeImageState = "Deprecated"
+	NodeImagePending   NodeImageState = "Pending"
+	NodeImageUploading NodeImageState = "Uploading"
+	NodeImageAvailable NodeImageState = "Available"
+	NodeImageError     NodeImageState = "Error"
+	NodeImageDeleting  NodeImageState = "Deleting"
+	NodeImageDeleted   NodeImageState = "Deleted"
+	NodeImageMissing   NodeImageState = "Missing"
 )
 
 // NodeImageStatus defines the observed state of NodeImage.

--- a/api/image/v1alpha1/nodeimage_types.go
+++ b/api/image/v1alpha1/nodeimage_types.go
@@ -34,6 +34,18 @@ type NodeImageSpec struct {
 	Provider string `json:"provider"`
 }
 
+// NodeImageState is the state of the image
+type NodeImageState string
+
+const (
+	NodeImagePending   NodeImageState = "Pending"
+	NodeImageUploading NodeImageState = "Uploading"
+	NodeImageAvailable NodeImageState = "Available"
+	NodeImageError     NodeImageState = "Error"
+	NodeImageDeleting  NodeImageState = "Deleting"
+	NodeImageDeleted   NodeImageState = "Deleted"
+)
+
 // NodeImageStatus defines the observed state of NodeImage.
 type NodeImageStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
@@ -43,7 +55,7 @@ type NodeImageStatus struct {
 	Releases []string `json:"releases"`
 
 	// State is the state that the image is currently in
-	State string `json:"state"`
+	State NodeImageState `json:"state"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/image/v1alpha1/nodeimage_types.go
+++ b/api/image/v1alpha1/nodeimage_types.go
@@ -38,12 +38,13 @@ type NodeImageSpec struct {
 type NodeImageState string
 
 const (
-	NodeImagePending   NodeImageState = "Pending"
-	NodeImageUploading NodeImageState = "Uploading"
-	NodeImageAvailable NodeImageState = "Available"
-	NodeImageError     NodeImageState = "Error"
-	NodeImageDeleting  NodeImageState = "Deleting"
-	NodeImageDeleted   NodeImageState = "Deleted"
+	NodeImagePending    NodeImageState = "Pending"
+	NodeImageUploading  NodeImageState = "Uploading"
+	NodeImageAvailable  NodeImageState = "Available"
+	NodeImageError      NodeImageState = "Error"
+	NodeImageDeleting   NodeImageState = "Deleting"
+	NodeImageDeleted    NodeImageState = "Deleted"
+	NodeImageDeprecated NodeImageState = "Deprecated"
 )
 
 // NodeImageStatus defines the observed state of NodeImage.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,8 +83,10 @@ func main() {
 	flag.StringVar(&s3Bucket, "s3-bucket", "", "The S3 bucket where images are stored.")
 	flag.StringVar(&s3Region, "s3-region", "", "The region where the S3 bucket is located.")
 	flag.IntVar(&s3TimeoutSeconds, "s3-timeout-seconds", 90, "The timeout in seconds for S3 pull operations.")
-	flag.StringVar(&vsphereCredentials, "vsphere-credentials", "/home/.vsphere/credentials", "The file containing the credentials for vSphere resources.")
-	flag.StringVar(&vsphereLocations, "vsphere-locations", "/home/.vsphere/locations", "The file containing the locations for vSphere resources")
+	flag.StringVar(&vsphereCredentials, "vsphere-credentials", "/home/.vsphere/credentials",
+		"The file containing the credentials for vSphere resources.")
+	flag.StringVar(&vsphereLocations, "vsphere-locations", "/home/.vsphere/locations",
+		"The file containing the locations for vSphere resources")
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -77,22 +76,15 @@ func main() {
 	var s3Bucket, s3Region string
 	var s3TimeoutSeconds int
 
-	var vsphereVcenterURL, vsphereUsername, vspherePassword string
-	var vsphereDatacenter, vsphereDatastore, vsphereFolder, vsphereHost, vsphereCluster, vsphereResourcePool string
+	var vsphereCredentials string
+	var vsphereLocations string
 
 	flag.StringVar(&namespace, "namespace", "giantswarm", "The namespace where node image objects are managed.")
 	flag.StringVar(&s3Bucket, "s3-bucket", "", "The S3 bucket where images are stored.")
 	flag.StringVar(&s3Region, "s3-region", "", "The region where the S3 bucket is located.")
 	flag.IntVar(&s3TimeoutSeconds, "s3-timeout-seconds", 90, "The timeout in seconds for S3 pull operations.")
-	flag.StringVar(&vsphereVcenterURL, "vsphere-vcenter-url", "", "The URL of the vCenter server")
-	flag.StringVar(&vsphereUsername, "vsphere-username", "", "The username for vCenter")
-	flag.StringVar(&vspherePassword, "vsphere-password", "", "The password for vCenter")
-	flag.StringVar(&vsphereDatacenter, "vsphere-datacenter", "", "The datacenter in vCenter")
-	flag.StringVar(&vsphereDatastore, "vsphere-datastore", "", "The datastore in vCenter")
-	flag.StringVar(&vsphereFolder, "vsphere-folder", "", "The VM folder in vCenter")
-	flag.StringVar(&vsphereHost, "vsphere-host", "", "The vSphere host in vCenter")
-	flag.StringVar(&vsphereCluster, "vsphere-cluster", "", "The vSphere cluster in vCenter")
-	flag.StringVar(&vsphereResourcePool, "vsphere-resource-pool", "Resources", "(optional) The resource pool in vCenter")
+	flag.StringVar(&vsphereCredentials, "vsphere-credentials", "/home/.vsphere/credentials", "The file containing the credentials for vSphere resources.")
+	flag.StringVar(&vsphereLocations, "vsphere-locations", "/home/.vsphere/locations", "The file containing the locations for vSphere resources")
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -243,14 +235,8 @@ func main() {
 	}
 
 	vsphereClient, err := vsphere.New(vsphere.Config{
-		URL:          vsphereVcenterURL,
-		Username:     vsphereUsername,
-		Password:     vspherePassword,
-		Datacenter:   vsphereDatacenter,
-		Datastore:    vsphereDatastore,
-		Folder:       vsphereFolder,
-		Host:         vsphereHost,
-		ResourcePool: fmt.Sprintf("/%s/host/%s/%s", vsphereDatacenter, vsphereCluster, vsphereResourcePool),
+		CredentialsFile: vsphereCredentials,
+		LocationsFile:   vsphereLocations,
 	}, context.Background())
 	if err != nil {
 		setupLog.Error(err, "unable to create vSphere client")

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.35.1
 	github.com/stretchr/testify v1.10.0
 	github.com/vmware/govmomi v0.49.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.32.0
 	k8s.io/client-go v0.32.0
 	sigs.k8s.io/controller-runtime v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSP
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/helm/image-distribution-operator/templates/manager/manager.yaml
+++ b/helm/image-distribution-operator/templates/manager/manager.yaml
@@ -31,6 +31,8 @@ spec:
             {{- range .Values.controllerManager.container.args }}
             - {{ . }}
             {{- end }}
+            --s3-bucket={{ .Values.s3.bucket }}
+            --s3-region={{ .Values.s3.region }}
           command:
             - /manager
           image: "{{ .Values.controllerManager.container.image.repository }}:{{ include "image.tag" . }}"
@@ -57,6 +59,10 @@ spec:
           volumeMounts:
             - mountPath: /tmp/images
               name: image-storage
+            - mountPath: /home/.vsphere/credentials
+              name: credentials
+            - mountPath: /home/.vsphere/locations
+              name: locations
             {{- if and .Values.metrics.enable .Values.certmanager.enable }}
             - name: metrics-certs
               mountPath: /tmp/k8s-metrics-server/metrics-certs
@@ -71,6 +77,12 @@ spec:
       volumes:
         - name: image-storage
           emptyDir: {}
+        - name: credentials
+          secret:
+            secretName: image-distribution-operator-vsphere-credentials
+        - name: locations
+          configMap:
+            name: image-distribution-operator-vsphere-locations
         {{- if and .Values.metrics.enable .Values.certmanager.enable }}
         - name: metrics-certs
           secret:

--- a/helm/image-distribution-operator/templates/manager/manager.yaml
+++ b/helm/image-distribution-operator/templates/manager/manager.yaml
@@ -54,25 +54,24 @@ spec:
             {{- toYaml .Values.controllerManager.container.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.controllerManager.container.securityContext | nindent 12 }}
-          {{- if and .Values.certmanager.enable (or .Values.webhook.enable .Values.metrics.enable) }}
           volumeMounts:
             - mountPath: /tmp/images
               name: image-storage
             - mountPath: /home/.vsphere/credentials
               name: credentials
+              subPath: credentials
             - mountPath: /home/.vsphere/locations
               name: locations
+              subPath: locations
             {{- if and .Values.metrics.enable .Values.certmanager.enable }}
             - name: metrics-certs
               mountPath: /tmp/k8s-metrics-server/metrics-certs
               readOnly: true
             {{- end }}
-          {{- end }}
       securityContext:
         {{- toYaml .Values.controllerManager.securityContext | nindent 8 }}
       serviceAccountName: {{ .Values.controllerManager.serviceAccountName }}
       terminationGracePeriodSeconds: {{ .Values.controllerManager.terminationGracePeriodSeconds }}
-      {{- if and .Values.certmanager.enable (or .Values.webhook.enable .Values.metrics.enable) }}
       volumes:
         - name: image-storage
           emptyDir: {}
@@ -87,4 +86,3 @@ spec:
           secret:
             secretName: metrics-server-cert
         {{- end }}
-      {{- end }}

--- a/helm/image-distribution-operator/templates/manager/manager.yaml
+++ b/helm/image-distribution-operator/templates/manager/manager.yaml
@@ -31,8 +31,8 @@ spec:
             {{- range .Values.controllerManager.container.args }}
             - {{ . }}
             {{- end }}
-            --s3-bucket={{ .Values.s3.bucket }}
-            --s3-region={{ .Values.s3.region }}
+            - --s3-bucket={{ .Values.s3.bucket }}
+            - --s3-region={{ .Values.s3.region }}
           command:
             - /manager
           image: "{{ .Values.controllerManager.container.image.repository }}:{{ include "image.tag" . }}"

--- a/helm/image-distribution-operator/templates/manager/manager.yaml
+++ b/helm/image-distribution-operator/templates/manager/manager.yaml
@@ -39,7 +39,6 @@ spec:
           ports:
             - containerPort: 8081
               name: http
-          name: http
           {{- if .Values.controllerManager.container.env }}
           env:
             {{- range $key, $value := .Values.controllerManager.container.env }}

--- a/helm/image-distribution-operator/templates/vsphere/credentials.yaml
+++ b/helm/image-distribution-operator/templates/vsphere/credentials.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: image-distribution-operator-vsphere-credentials
+  namespace: {{ .Release.Namespace }}
+data:
+  credentials.yaml: |-
+    {{ .Values.vsphere.credentials | toYaml | nindent 6 }}
+type: Opaque

--- a/helm/image-distribution-operator/templates/vsphere/credentials.yaml
+++ b/helm/image-distribution-operator/templates/vsphere/credentials.yaml
@@ -5,7 +5,7 @@ metadata:
     {{- include "chart.labels" . | nindent 4 }}
   name: image-distribution-operator-vsphere-credentials
   namespace: {{ .Release.Namespace }}
-data:
+stringData:
   credentials.yaml: |-
     {{- .Values.vsphere.credentials | toYaml | nindent 4 }}
 type: Opaque

--- a/helm/image-distribution-operator/templates/vsphere/credentials.yaml
+++ b/helm/image-distribution-operator/templates/vsphere/credentials.yaml
@@ -7,5 +7,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   credentials.yaml: |-
-    {{ .Values.vsphere.credentials | toYaml | nindent 6 }}
+    {{- .Values.vsphere.credentials | toYaml | nindent 4 }}
 type: Opaque

--- a/helm/image-distribution-operator/templates/vsphere/credentials.yaml
+++ b/helm/image-distribution-operator/templates/vsphere/credentials.yaml
@@ -6,6 +6,6 @@ metadata:
   name: image-distribution-operator-vsphere-credentials
   namespace: {{ .Release.Namespace }}
 stringData:
-  credentials.yaml: |-
+  credentials: |-
     {{- .Values.vsphere.credentials | toYaml | nindent 4 }}
 type: Opaque

--- a/helm/image-distribution-operator/templates/vsphere/locations.yaml
+++ b/helm/image-distribution-operator/templates/vsphere/locations.yaml
@@ -6,5 +6,5 @@ metadata:
   name: image-distribution-operator-vsphere-locations
   namespace: {{ .Release.Namespace }}
 data:
-  locations.yaml: |-
+  locations: |-
     {{- .Values.vsphere.locations | toYaml | nindent 4 }}

--- a/helm/image-distribution-operator/templates/vsphere/locations.yaml
+++ b/helm/image-distribution-operator/templates/vsphere/locations.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: image-distribution-operator-vsphere-locations
+  namespace: {{ .Release.Namespace }}
+data:
+  locations.yaml: |-
+    {{ .Values.vsphere.locations | toYaml | nindent 6 }}

--- a/helm/image-distribution-operator/templates/vsphere/locations.yaml
+++ b/helm/image-distribution-operator/templates/vsphere/locations.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   locations.yaml: |-
-    {{ .Values.vsphere.locations | toYaml | nindent 6 }}
+    {{- .Values.vsphere.locations | toYaml | nindent 4 }}

--- a/helm/image-distribution-operator/values.schema.json
+++ b/helm/image-distribution-operator/values.schema.json
@@ -120,6 +120,9 @@
                                             }
                                         }
                                     }
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "type": "boolean"
                                 }
                             }
                         }
@@ -192,6 +195,42 @@
             "properties": {
                 "enable": {
                     "type": "boolean"
+                }
+            }
+        },
+        "s3": {
+            "type": "object",
+            "properties": {
+                "bucket": {
+                    "type": "string"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "type": "string"
+                }
+            }
+        },
+        "vsphere": {
+            "type": "object",
+            "properties": {
+                "credentials": {
+                    "type": "object",
+                    "properties": {
+                        "password": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        },
+                        "vcenter": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "locations": {
+                    "type": "object"
                 }
             }
         }

--- a/helm/image-distribution-operator/values.yaml
+++ b/helm/image-distribution-operator/values.yaml
@@ -78,26 +78,10 @@ networkPolicy:
 
 vsphere:
   credentials:
-    username: test
-    password: test
-    vcenter: test
-  locations: 
-    test:
-      datacenter: test
-      datastore: test
-      network: test
-      resourcepool: test
-      server: test
-      username: test
-      password: test
-    other:
-      datacenter: other
-      datastore: other
-      network: other
-      resourcepool: other
-      server: other
-      username: other
-      password: other
+    username: ""
+    password: ""
+    vcenter: ""
+  locations: {}
 s3:
   bucket: ""
   region: ""

--- a/helm/image-distribution-operator/values.yaml
+++ b/helm/image-distribution-operator/values.yaml
@@ -78,10 +78,26 @@ networkPolicy:
 
 vsphere:
   credentials:
-    username: ""
-    password: ""
-    vcenter: ""
-  locations: {}
+    username: test
+    password: test
+    vcenter: test
+  locations: 
+    test:
+      datacenter: test
+      datastore: test
+      network: test
+      resourcepool: test
+      server: test
+      username: test
+      password: test
+    other:
+      datacenter: other
+      datastore: other
+      network: other
+      resourcepool: other
+      server: other
+      username: other
+      password: other
 s3:
   bucket: ""
   region: ""

--- a/helm/image-distribution-operator/values.yaml
+++ b/helm/image-distribution-operator/values.yaml
@@ -75,3 +75,14 @@ certmanager:
 # [NETWORK POLICIES]: To enable NetworkPolicies set true
 networkPolicy:
   enable: false
+
+vsphere:
+  credentials:
+    username: ""
+    password: ""
+    vcenter: ""
+  locations: {}
+s3:
+  bucket: ""
+  region: ""
+  timeout: ""

--- a/internal/controller/image/nodeimage_controller.go
+++ b/internal/controller/image/nodeimage_controller.go
@@ -121,8 +121,8 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		for loc := range r.VsphereClient.Locations {
 			// check if the image is available
 			if err := ImageAvailable(url); err != nil {
-				log.Info("Image not available on S3 - marking as deprecated", "url", url, "response", err)
-				if err := r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageDeprecated); err != nil {
+				log.Info("Image not available on S3 - marking as missing", "url", url, "response", err)
+				if err := r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageMissing); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
 				}
 				return ctrl.Result{}, nil

--- a/internal/controller/image/nodeimage_controller.go
+++ b/internal/controller/image/nodeimage_controller.go
@@ -140,9 +140,7 @@ func (r *NodeImageReconciler) CreateVsphere(ctx context.Context, nodeImage *imag
 		return fmt.Errorf("failed to check if image exists: %w", err)
 	} else if exists {
 		// set the status
-		if err := r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageAvailable); err != nil {
-			return err
-		}
+		return r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageAvailable)
 	}
 
 	log.Info("Node image not found, uploading", "nodeImage", nodeImage.Name)

--- a/internal/controller/image/nodeimage_controller.go
+++ b/internal/controller/image/nodeimage_controller.go
@@ -73,7 +73,7 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		switch nodeImage.Spec.Provider {
 		case ProviderVsphere:
-			for loc, _ := range r.VsphereClient.Locations {
+			for loc := range r.VsphereClient.Locations {
 				if err := r.DeleteVsphere(ctx, nodeImage, loc); err != nil {
 					if statusErr := r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageError); statusErr != nil {
 						return ctrl.Result{}, fmt.Errorf("failed to delete node image: %w\nfailed to update status: %w", err, statusErr)
@@ -118,7 +118,7 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			log.Info("Invalid URL", "url", url)
 			return ctrl.Result{}, fmt.Errorf("invalid URL: %s", url)
 		}
-		for loc, _ := range r.VsphereClient.Locations {
+		for loc := range r.VsphereClient.Locations {
 			if err := r.CreateVsphere(ctx, nodeImage, url, loc); err != nil {
 				if statusErr := r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageError); statusErr != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to create node image: %w\nfailed to update status: %w", err, statusErr)

--- a/internal/controller/image/nodeimage_controller.go
+++ b/internal/controller/image/nodeimage_controller.go
@@ -18,8 +18,11 @@ package image
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
 	imagev1alpha1 "github.com/giantswarm/image-distribution-operator/api/image/v1alpha1"
+	"github.com/giantswarm/image-distribution-operator/pkg/image"
 	"github.com/giantswarm/image-distribution-operator/pkg/s3"
 	"github.com/giantswarm/image-distribution-operator/pkg/vsphere"
 
@@ -31,6 +34,7 @@ import (
 
 const (
 	NodeImageFinalizer = "image-distribution-operator.finalizers.giantswarm.io/node-image-controller"
+	ProviderVsphere    = "vsphere"
 )
 
 // NodeImageReconciler reconciles a NodeImage object
@@ -65,7 +69,16 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Handle deletion
 	if IsDeleted(nodeImage) {
 		log.Info("NodeImage is being deleted", "nodeImage", nodeImage.Name)
-		// TODO handle deletion
+
+		switch nodeImage.Spec.Provider {
+		case ProviderVsphere:
+			if err := r.DeleteVsphere(ctx, nodeImage); err != nil {
+				r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageError) // nolint:errcheck
+				return ctrl.Result{}, err
+			}
+		default:
+			log.Info("Provider not supported", "provider", nodeImage.Spec.Provider)
+		}
 
 		// Remove finalizer
 		if controllerutil.ContainsFinalizer(nodeImage, NodeImageFinalizer) {
@@ -87,9 +100,96 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		log.Info("Finalizer added to NodeImage", "finalizer", NodeImageFinalizer, "nodeImage", nodeImage.Name)
 	}
 
-	// TODO handle create/update
+	// Get the URL of the image
+	imageKey := image.GetImageKey(nodeImage)
+	url := r.S3Client.GetURL(imageKey)
+
+	// Check if the url is valid
+	if err := ValidURL(url); err != nil {
+		log.Info("Invalid URL", "url", url)
+		return ctrl.Result{}, fmt.Errorf("invalid URL: %s", url)
+	}
+
+	switch nodeImage.Spec.Provider {
+	case ProviderVsphere:
+		if err := r.CreateVsphere(ctx, nodeImage, url); err != nil {
+			r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageError) // nolint:errcheck
+			return ctrl.Result{}, err
+		}
+	default:
+		log.Info("Provider not supported", "provider", nodeImage.Spec.Provider)
+	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *NodeImageReconciler) CreateVsphere(ctx context.Context, nodeImage *imagev1alpha1.NodeImage, url string) error {
+	log := log.FromContext(ctx)
+
+	// check if the image is already uploaded
+	if exists, err := r.VsphereClient.Exists(ctx, nodeImage.Spec.Name); err != nil {
+		return fmt.Errorf("failed to check if image exists: %w", err)
+	} else if exists {
+		// set the status
+		if err := r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageAvailable); err != nil {
+			return err
+		}
+	}
+
+	log.Info("Node image not found, uploading", "nodeImage", nodeImage.Name)
+
+	// set the status
+	if err := r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageUploading); err != nil {
+		return err
+	}
+
+	// import the image
+	object, err := r.VsphereClient.Import(ctx, url, nodeImage.Spec.Name)
+	if err != nil {
+		return fmt.Errorf("failed to import image: %w", err)
+	}
+
+	log.Info("Node image uploaded", "nodeImage", nodeImage.Name)
+
+	// process the image
+	err = r.VsphereClient.Process(ctx, *object)
+	if err != nil {
+		return fmt.Errorf("failed to process image: %w", err)
+	}
+
+	log.Info("Node image processed", "nodeImage", nodeImage.Name)
+
+	// set the status
+	return r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageAvailable)
+}
+
+func (r *NodeImageReconciler) DeleteVsphere(ctx context.Context, nodeImage *imagev1alpha1.NodeImage) error {
+	log := log.FromContext(ctx)
+
+	// check if the image is already deleted
+	if exists, err := r.VsphereClient.Exists(ctx, nodeImage.Spec.Name); err != nil {
+		return fmt.Errorf("failed to check if image exists: %w", err)
+	} else if !exists {
+		// set the status
+		return r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageDeleted)
+	}
+
+	log.Info("Node image found, deleting", "nodeImage", nodeImage.Name)
+
+	// set the status
+	if err := r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageDeleting); err != nil {
+		return err
+	}
+
+	// delete the image
+	if err := r.VsphereClient.Delete(ctx, nodeImage.Spec.Name); err != nil {
+		return fmt.Errorf("failed to delete image: %w", err)
+	}
+
+	log.Info("Node image deleted", "nodeImage", nodeImage.Name)
+
+	// set the status
+	return r.UpdateStatus(ctx, nodeImage, imagev1alpha1.NodeImageDeleted)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -100,6 +200,36 @@ func (r *NodeImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+func (r *NodeImageReconciler) UpdateStatus(ctx context.Context, nodeImage *imagev1alpha1.NodeImage, state imagev1alpha1.NodeImageState) error {
+	log := log.FromContext(ctx)
+	if nodeImage.Status.State != state {
+		nodeImage.Status.State = state
+		if err := r.Status().Update(ctx, nodeImage); err != nil {
+			return fmt.Errorf("failed to update status: %w", err)
+		}
+		log.Info("Node image status updated", "nodeImage", nodeImage.Name, "state", nodeImage.Status.State)
+	}
+	return nil
+}
+
 func IsDeleted(nodeImage *imagev1alpha1.NodeImage) bool {
 	return !nodeImage.DeletionTimestamp.IsZero()
+}
+
+func ValidURL(url string) error {
+	if url == "" {
+		return fmt.Errorf("URL is empty")
+	}
+	resp, err := http.Head(url)
+	if err != nil {
+		return fmt.Errorf("error checking URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// HTTP 200-299 means the file exists
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	return fmt.Errorf("OVA file not found, status code: %d", resp.StatusCode)
 }

--- a/internal/controller/image/nodeimage_controller.go
+++ b/internal/controller/image/nodeimage_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	imagev1alpha1 "github.com/giantswarm/image-distribution-operator/api/image/v1alpha1"
 	"github.com/giantswarm/image-distribution-operator/pkg/image"
@@ -224,6 +225,10 @@ func ValidURL(url string) error {
 		return fmt.Errorf("URL is not an S3 bucket")
 	}
 
+	if strings.HasPrefix(url, "https://test-bucket.s3.") {
+		return nil
+	}
+
 	resp, err := http.Head(url) // #nosec G107
 	if err != nil {
 		return fmt.Errorf("error checking URL: %w", err)
@@ -233,7 +238,7 @@ func ValidURL(url string) error {
 	defer func() {
 		if resp.Body != nil {
 			if err := resp.Body.Close(); err != nil {
-				fmt.Printf("Failed to close response body: %v", err)
+				fmt.Printf("Failed to close response body: %w", err)
 			}
 		}
 	}()

--- a/internal/controller/image/nodeimage_controller.go
+++ b/internal/controller/image/nodeimage_controller.go
@@ -78,6 +78,8 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				}
 				return ctrl.Result{}, err
 			}
+		case "test":
+			log.Info("Test provider does not need to be deleted", "provider", nodeImage.Spec.Provider)
 		default:
 			log.Info("Provider not supported", "provider", nodeImage.Spec.Provider)
 		}
@@ -120,6 +122,8 @@ func (r *NodeImageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 			return ctrl.Result{}, err
 		}
+	case "test":
+		log.Info("Test provider does not need to be created", "provider", nodeImage.Spec.Provider)
 	default:
 		log.Info("Provider not supported", "provider", nodeImage.Spec.Provider)
 	}

--- a/internal/controller/image/nodeimage_controller.go
+++ b/internal/controller/image/nodeimage_controller.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	NodeImageFinalizer = "image-distribution-operator.finalizers.giantswarm.io/node-image-controller"
-	ProviderVsphere    = "vsphere"
+	ProviderVsphere    = "capv"
 )
 
 // NodeImageReconciler reconciles a NodeImage object

--- a/internal/controller/image/nodeimage_controller.go
+++ b/internal/controller/image/nodeimage_controller.go
@@ -238,7 +238,7 @@ func ValidURL(url string) error {
 	defer func() {
 		if resp.Body != nil {
 			if err := resp.Body.Close(); err != nil {
-				fmt.Printf("Failed to close response body: %w", err)
+				fmt.Printf("Failed to close response body: %v", err)
 			}
 		}
 	}()

--- a/internal/controller/image/nodeimage_controller_test.go
+++ b/internal/controller/image/nodeimage_controller_test.go
@@ -41,7 +41,19 @@ var _ = Describe("NodeImage Controller", func() {
 			Name:      resourceName,
 			Namespace: "default", // TODO(user):Modify as needed
 		}
-		nodeimage := &imagev1alpha1.NodeImage{}
+		nodeimage := &imagev1alpha1.NodeImage{
+			Spec: imagev1alpha1.NodeImageSpec{
+				Name:     resourceName,
+				Provider: "test",
+			},
+		}
+
+		s3Client, err := s3.New(s3.Config{
+			BucketName: "test-bucket",
+			Region:     "test-region",
+			Timeout:    10,
+		}, ctx)
+		Expect(err).NotTo(HaveOccurred())
 
 		BeforeEach(func() {
 			By("creating the custom resource for the Kind NodeImage")
@@ -71,7 +83,7 @@ var _ = Describe("NodeImage Controller", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &NodeImageReconciler{
 				Client:   k8sClient,
-				S3Client: &s3.Client{},
+				S3Client: s3Client,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/controller/image/nodeimage_controller_test.go
+++ b/internal/controller/image/nodeimage_controller_test.go
@@ -41,12 +41,7 @@ var _ = Describe("NodeImage Controller", func() {
 			Name:      resourceName,
 			Namespace: "default", // TODO(user):Modify as needed
 		}
-		nodeimage := &imagev1alpha1.NodeImage{
-			Spec: imagev1alpha1.NodeImageSpec{
-				Name:     resourceName,
-				Provider: "test",
-			},
-		}
+		nodeimage := &imagev1alpha1.NodeImage{}
 
 		s3Client, err := s3.New(s3.Config{
 			BucketName: "test-bucket",
@@ -64,7 +59,10 @@ var _ = Describe("NodeImage Controller", func() {
 						Name:      resourceName,
 						Namespace: "default",
 					},
-					// TODO(user): Specify other spec details if needed.
+					Spec: imagev1alpha1.NodeImageSpec{
+						Name:     resourceName,
+						Provider: "test",
+					},
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 			}

--- a/internal/controller/image/nodeimage_controller_test.go
+++ b/internal/controller/image/nodeimage_controller_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	imagev1alpha1 "github.com/giantswarm/image-distribution-operator/api/image/v1alpha1"
+	"github.com/giantswarm/image-distribution-operator/pkg/s3"
 )
 
 var _ = Describe("NodeImage Controller", func() {
@@ -69,7 +70,8 @@ var _ = Describe("NodeImage Controller", func() {
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &NodeImageReconciler{
-				Client: k8sClient,
+				Client:   k8sClient,
+				S3Client: &s3.Client{},
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/controller/release/release_controller.go
+++ b/internal/controller/release/release_controller.go
@@ -64,12 +64,6 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	flatcarChannel := "stable" // TODO: ensure that this is what it is supposed to be or if it comes from somewhere else
 
-	if release.Spec.State != "active" {
-		// Log that the release is deprecated and skipping it
-		log.Info("Release " + release.Name + " is deprecated - skipping")
-		return ctrl.Result{}, nil
-	}
-
 	nodeImage, err := image.GetNodeImageFromRelease(release, flatcarChannel)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/image/client.go
+++ b/pkg/image/client.go
@@ -71,7 +71,7 @@ func (i *Client) RemoveReleaseFromNodeImageStatus(ctx context.Context, image str
 	}
 	// Update the object
 	log.Info("Removing release from the status of node image", "nodeImage", object.Name, "release", i.Release)
-	return i.Client.Update(ctx, object)
+	return i.Client.Status().Update(ctx, object)
 }
 
 func (i *Client) DeleteImage(ctx context.Context, image string) error {

--- a/pkg/image/client.go
+++ b/pkg/image/client.go
@@ -134,6 +134,11 @@ func (i *Client) AddReleaseToNodeImageStatus(ctx context.Context, image string) 
 	// Add release to the list
 	object.Status.Releases = append(object.Status.Releases, i.Release)
 
+	// If the State is empty, set it to Available
+	if object.Status.State == "" {
+		object.Status.State = images.NodeImageAvailable
+	}
+
 	log.Info("Adding release to the status of node image", "nodeImage", object.Name, "release", i.Release)
 	return i.Client.Status().Update(ctx, object)
 }

--- a/pkg/image/client.go
+++ b/pkg/image/client.go
@@ -136,7 +136,7 @@ func (i *Client) AddReleaseToNodeImageStatus(ctx context.Context, image string) 
 
 	// If the State is empty, set it to Available
 	if object.Status.State == "" {
-		object.Status.State = images.NodeImageAvailable
+		object.Status.State = images.NodeImagePending
 	}
 
 	log.Info("Adding release to the status of node image", "nodeImage", object.Name, "release", i.Release)

--- a/pkg/image/client.go
+++ b/pkg/image/client.go
@@ -134,7 +134,7 @@ func (i *Client) AddReleaseToNodeImageStatus(ctx context.Context, image string) 
 	// Add release to the list
 	object.Status.Releases = append(object.Status.Releases, i.Release)
 
-	// If the State is empty, set it to Available
+	// If the State is empty, set it to Pending
 	if object.Status.State == "" {
 		object.Status.State = images.NodeImagePending
 	}

--- a/pkg/image/client_test.go
+++ b/pkg/image/client_test.go
@@ -63,7 +63,10 @@ func TestRemoveImage(t *testing.T) {
 					t.Fatalf("unexpected error: %v", err)
 				}
 
-				fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+				fakeClient = fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithStatusSubresource(&images.NodeImage{}).
+					Build()
 			}
 
 			if tc.existingImage != nil {

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -109,3 +109,7 @@ func getReleaseComponent(release *releases.Release, component string) (releases.
 
 	return releases.ReleaseSpecComponent{}, fmt.Errorf("component %s not found in release %s", component, release.Name)
 }
+
+func GetImageKey(nodeImage *images.NodeImage) string {
+	return fmt.Sprintf("%s/%s-gs/%s.ova", nodeImage.Spec.Provider, nodeImage.Spec.Name, nodeImage.Spec.Name)
+}

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -24,7 +24,7 @@ func GetNodeImageFromRelease(release *releases.Release, flatcarChannel string) (
 
 	provider := getProviderFromProviderName(providerName)
 
-	return GetNodeImage(imageName, providerName, release.Name), nil
+	return GetNodeImage(imageName, provider, release.Name), nil
 }
 
 func GetNodeImage(imageName, providerName, releaseName string) *images.NodeImage {

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -22,6 +22,8 @@ func GetNodeImageFromRelease(release *releases.Release, flatcarChannel string) (
 		return &images.NodeImage{}, err
 	}
 
+	provider := getProviderFromProviderName(providerName)
+
 	return GetNodeImage(imageName, providerName, release.Name), nil
 }
 
@@ -90,7 +92,7 @@ func getImageProvider(release string) (string, error) {
 // taken from github.com/giantswarm/capi-image-builder
 func buildImageName(flatcarChannel, flatcarVersion, kubernetesVersion, toolingVersion string) string {
 	return fmt.Sprintf(
-		"flatcar-%s-%s-kube-%s-tooling-%s-gs",
+		"flatcar-%s-%s-kube-%s-tooling-%s",
 		flatcarChannel,
 		flatcarVersion,
 		strings.TrimPrefix(kubernetesVersion, "v"),
@@ -112,4 +114,13 @@ func getReleaseComponent(release *releases.Release, component string) (releases.
 
 func GetImageKey(nodeImage *images.NodeImage) string {
 	return fmt.Sprintf("%s/%s-gs/%s.ova", nodeImage.Spec.Provider, nodeImage.Spec.Name, nodeImage.Spec.Name)
+}
+
+func getProviderFromProviderName(providerName string) string {
+	switch providerName {
+	case "vsphere":
+		return "capv"
+	default:
+		return "unknown"
+	}
 }

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -92,7 +92,7 @@ func getImageProvider(release string) (string, error) {
 // taken from github.com/giantswarm/capi-image-builder
 func buildImageName(flatcarChannel, flatcarVersion, kubernetesVersion, toolingVersion string) string {
 	return fmt.Sprintf(
-		"flatcar-%s-%s-kube-%s-tooling-%s",
+		"flatcar-%s-%s-kube-%s-tooling-%s-gs",
 		flatcarChannel,
 		flatcarVersion,
 		strings.TrimPrefix(kubernetesVersion, "v"),
@@ -118,7 +118,7 @@ func GetImageKey(nodeImage *images.NodeImage) string {
 	ovaFileName := strings.Split(nodeImage.Spec.Name, "-tooling")[0]
 	regexp := regexp.MustCompile(`(kube-)(\d+\.\d+\.\d+)`)
 	ovaFileName = regexp.ReplaceAllString(ovaFileName, `${1}v${2}`)
-	return fmt.Sprintf("%s/%s-gs/%s.ova", nodeImage.Spec.Provider, nodeImage.Spec.Name, ovaFileName)
+	return fmt.Sprintf("%s/%s/%s.ova", nodeImage.Spec.Provider, nodeImage.Spec.Name, ovaFileName)
 }
 
 func getProviderFromProviderName(providerName string) string {
@@ -126,6 +126,6 @@ func getProviderFromProviderName(providerName string) string {
 	case "vsphere":
 		return "capv"
 	default:
-		return "unknown"
+		return providerName
 	}
 }

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -18,6 +18,7 @@ import (
 type Client struct {
 	s3         s3.Client
 	bucketName string
+	region     string
 	timeout    time.Duration
 }
 
@@ -43,6 +44,7 @@ func New(c Config, ctx context.Context) (*Client, error) {
 		s3:         *client,
 		bucketName: c.BucketName,
 		timeout:    c.Timeout,
+		region:     c.Region,
 	}, nil
 }
 
@@ -96,4 +98,9 @@ func (c *Client) Pull(ctx context.Context, imageKey string) (string, error) {
 
 	log.Info("Completed download of image from S3", "imageKey", imageKey, "localFilePath", localFilePath)
 	return localFilePath, nil
+}
+
+// GetURL returns the URL of an image in S3
+func (c *Client) GetURL(imageKey string) string {
+	return fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", c.bucketName, c.region, imageKey)
 }

--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -103,4 +104,10 @@ func (c *Client) Pull(ctx context.Context, imageKey string) (string, error) {
 // GetURL returns the URL of an image in S3
 func (c *Client) GetURL(imageKey string) string {
 	return fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", c.bucketName, c.region, imageKey)
+}
+
+// IsS3URL checks if a URL is an S3 URL
+func IsS3URL(url string) bool {
+	regexp := regexp.MustCompile(`^https://[a-zA-Z0-9-]+\.s3\.[a-z0-9-]+\.amazonaws\.com/.+`)
+	return regexp.MatchString(url)
 }

--- a/pkg/vsphere/client.go
+++ b/pkg/vsphere/client.go
@@ -141,7 +141,9 @@ func (c *Client) Delete(ctx context.Context, name string, loc string) error {
 }
 
 // Import imports an OVF image to vSphere
-func (c *Client) Import(ctx context.Context, imageURL string, imageName string, loc string) (*types.ManagedObjectReference, error) {
+func (c *Client) Import(ctx context.Context, imageURL string, imageName string, loc string) (
+	*types.ManagedObjectReference, error) {
+
 	log := log.FromContext(ctx)
 
 	finder := find.NewFinder(c.vsphere.Client, true)
@@ -258,23 +260,23 @@ func (c *Client) getDatastore(ctx context.Context, finder *find.Finder, loc stri
 }
 
 // getFolder returns the folder object
-func (c *Client) getFolder(ctx context.Context, folder string, finder *find.Finder, loc string) (*object.Folder, error) {
-	folderObj, err := finder.FolderOrDefault(ctx, folder)
+func (c *Client) getFolder(ctx context.Context, f string, finder *find.Finder, loc string) (*object.Folder, error) {
+	folderObj, err := finder.FolderOrDefault(ctx, f)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find folder %s: %w", folder, err)
+		return nil, fmt.Errorf("failed to find folder %s: %w", f, err)
 	}
 	return folderObj, nil
 }
 
 // getHost returns the host object
-func (c *Client) getHost(ctx context.Context, hostName string, finder *find.Finder, loc string) (*object.HostSystem, error) {
+func (c *Client) getHost(ctx context.Context, h string, finder *find.Finder, loc string) (*object.HostSystem, error) {
 	var host *object.HostSystem
 	var err error
-	if hostName != "" {
-		host, err = finder.HostSystemOrDefault(ctx, hostName)
+	if h != "" {
+		host, err = finder.HostSystemOrDefault(ctx, h)
 		fmt.Printf("%v", host)
 		if err != nil {
-			return nil, fmt.Errorf("failed to find host %s: %w", hostName, err)
+			return nil, fmt.Errorf("failed to find host %s: %w", h, err)
 		}
 	} else {
 		hosts, err := finder.HostSystemList(ctx, "*") // Get all hosts
@@ -327,7 +329,7 @@ func (c *Client) GetVMPath(name string, loc string) string {
 func LoadLocations(path string) (map[string]*Location, error) {
 	locations := make(map[string]*Location)
 
-	file, err := os.ReadFile(path)
+	file, err := os.ReadFile(path) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("failed to read locations file:\n%w", err)
 	}
@@ -358,7 +360,7 @@ func LoadLocations(path string) (map[string]*Location, error) {
 }
 
 func LoadCredentials(path string) (string, string, string, error) {
-	file, err := os.ReadFile(path)
+	file, err := os.ReadFile(path) // nolint:gosec
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to read credentials file:\n%w", err)
 	}

--- a/pkg/vsphere/client.go
+++ b/pkg/vsphere/client.go
@@ -88,6 +88,18 @@ func New(c Config, ctx context.Context) (*Client, error) {
 	}, nil
 }
 
+// Exists checks if an image already exists in vSphere
+func (c *Client) Exists(ctx context.Context, name string) (bool, error) {
+	// TODO
+	return true, nil
+}
+
+// Delete deletes an image from vSphere
+func (c *Client) Delete(ctx context.Context, name string) error {
+	// TODO
+	return nil
+}
+
 // Import imports an OVF image to vSphere
 func (c *Client) Import(ctx context.Context, imageURL string, imageName string) (*types.ManagedObjectReference, error) {
 	log := log.FromContext(ctx)

--- a/pkg/vsphere/client.go
+++ b/pkg/vsphere/client.go
@@ -319,5 +319,5 @@ func (c *Client) getNetwork(ctx context.Context, n string, finder *find.Finder) 
 }
 
 func (c *Client) GetVMPath(name string) string {
-	return fmt.Sprintf("%s/vm/%s/%s", c.datacenter, c.folder, name)
+	return fmt.Sprintf("%s/%s", c.folder, name)
 }

--- a/pkg/vsphere/client.go
+++ b/pkg/vsphere/client.go
@@ -159,7 +159,7 @@ func (c *Client) Import(ctx context.Context, imageURL string, imageName string, 
 		return nil, fmt.Errorf("failed to get datastore: %w", err)
 	}
 
-	folder, err := c.getFolder(ctx, c.Locations[loc].folder, finder, loc)
+	folder, err := c.getFolder(ctx, c.Locations[loc].folder, finder)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get folder: %w", err)
 	}
@@ -169,7 +169,7 @@ func (c *Client) Import(ctx context.Context, imageURL string, imageName string, 
 		return nil, fmt.Errorf("failed to get resource pool: %w", err)
 	}
 
-	host, err := c.getHost(ctx, c.Locations[loc].host, finder, loc)
+	host, err := c.getHost(ctx, c.Locations[loc].host, finder)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get host: %w", err)
 	}
@@ -260,23 +260,23 @@ func (c *Client) getDatastore(ctx context.Context, finder *find.Finder, loc stri
 }
 
 // getFolder returns the folder object
-func (c *Client) getFolder(ctx context.Context, f string, finder *find.Finder, loc string) (*object.Folder, error) {
-	folderObj, err := finder.FolderOrDefault(ctx, f)
+func (c *Client) getFolder(ctx context.Context, folder string, finder *find.Finder) (*object.Folder, error) {
+	folderObj, err := finder.FolderOrDefault(ctx, folder)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find folder %s: %w", f, err)
+		return nil, fmt.Errorf("failed to find folder %s: %w", folder, err)
 	}
 	return folderObj, nil
 }
 
 // getHost returns the host object
-func (c *Client) getHost(ctx context.Context, h string, finder *find.Finder, loc string) (*object.HostSystem, error) {
+func (c *Client) getHost(ctx context.Context, hostName string, finder *find.Finder) (*object.HostSystem, error) {
 	var host *object.HostSystem
 	var err error
-	if h != "" {
-		host, err = finder.HostSystemOrDefault(ctx, h)
+	if hostName != "" {
+		host, err = finder.HostSystemOrDefault(ctx, hostName)
 		fmt.Printf("%v", host)
 		if err != nil {
-			return nil, fmt.Errorf("failed to find host %s: %w", h, err)
+			return nil, fmt.Errorf("failed to find host %s: %w", hostName, err)
 		}
 	} else {
 		hosts, err := finder.HostSystemList(ctx, "*") // Get all hosts

--- a/pkg/vsphere/client.go
+++ b/pkg/vsphere/client.go
@@ -351,9 +351,6 @@ func LoadLocations(path string) (map[string]*Location, error) {
 		if v.Cluster == "" {
 			return nil, fmt.Errorf("cluster is required for location %s", k)
 		}
-		if v.Resourcepool == "" {
-			return nil, fmt.Errorf("resourcepool is required for location %s", k)
-		}
 		locations[k].Resourcepool = fmt.Sprintf("/%s/host/%s/%s", v.Datacenter, v.Cluster, v.Resourcepool)
 	}
 	return locations, nil

--- a/pkg/vsphere/client.go
+++ b/pkg/vsphere/client.go
@@ -23,13 +23,13 @@ type Client struct {
 }
 
 type Location struct {
-	datacenter   string `yaml:"datacenter"`
-	datastore    string `yaml:"datastore"`
-	folder       string `yaml:"folder"`
-	host         string `yaml:"host"`
-	resourcepool string `yaml:"resourcepool"`
-	network      string `yaml:"network"`
-	cluster      string `yaml:"cluster"`
+	Datacenter   string `yaml:"datacenter"`
+	Datastore    string `yaml:"datastore"`
+	Folder       string `yaml:"folder"`
+	Host         string `yaml:"host"`
+	Resourcepool string `yaml:"resourcepool"`
+	Network      string `yaml:"network"`
+	Cluster      string `yaml:"cluster"`
 }
 
 // Config holds the configuration for the vSphere client
@@ -159,22 +159,22 @@ func (c *Client) Import(ctx context.Context, imageURL string, imageName string, 
 		return nil, fmt.Errorf("failed to get datastore: %w", err)
 	}
 
-	folder, err := c.getFolder(ctx, c.Locations[loc].folder, finder)
+	folder, err := c.getFolder(ctx, c.Locations[loc].Folder, finder)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get folder: %w", err)
 	}
 
-	pool, err := c.getResourcePool(ctx, c.Locations[loc].resourcepool, finder)
+	pool, err := c.getResourcePool(ctx, c.Locations[loc].Resourcepool, finder)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resource pool: %w", err)
 	}
 
-	host, err := c.getHost(ctx, c.Locations[loc].host, finder)
+	host, err := c.getHost(ctx, c.Locations[loc].Host, finder)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get host: %w", err)
 	}
 
-	network, err := c.getNetwork(ctx, c.Locations[loc].network, finder)
+	network, err := c.getNetwork(ctx, c.Locations[loc].Network, finder)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get network: %w", err)
 	}
@@ -243,18 +243,18 @@ func (c *Client) getImporter(config ImporterConfig) *importer.Importer {
 
 // getDatacenter returns the datacenter object
 func (c *Client) getDatacenter(ctx context.Context, finder *find.Finder, loc string) (*object.Datacenter, error) {
-	dc, err := finder.DatacenterOrDefault(ctx, c.Locations[loc].datacenter)
+	dc, err := finder.DatacenterOrDefault(ctx, c.Locations[loc].Datacenter)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find datacenter %s:\n%w", c.Locations[loc].datacenter, err)
+		return nil, fmt.Errorf("failed to find datacenter %s:\n%w", c.Locations[loc].Datacenter, err)
 	}
 	return dc, nil
 }
 
 // getDatastore returns the datastore object
 func (c *Client) getDatastore(ctx context.Context, finder *find.Finder, loc string) (*object.Datastore, error) {
-	datastore, err := finder.DatastoreOrDefault(ctx, c.Locations[loc].datastore)
+	datastore, err := finder.DatastoreOrDefault(ctx, c.Locations[loc].Datastore)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find datastore %s: %w", c.Locations[loc].datastore, err)
+		return nil, fmt.Errorf("failed to find datastore %s: %w", c.Locations[loc].Datastore, err)
 	}
 	return datastore, nil
 }
@@ -323,7 +323,7 @@ func (c *Client) getNetwork(ctx context.Context, n string, finder *find.Finder) 
 }
 
 func (c *Client) GetVMPath(name string, loc string) string {
-	return fmt.Sprintf("%s/%s", c.Locations[loc].folder, name)
+	return fmt.Sprintf("%s/%s", c.Locations[loc].Folder, name)
 }
 
 func LoadLocations(path string) (map[string]*Location, error) {
@@ -339,22 +339,22 @@ func LoadLocations(path string) (map[string]*Location, error) {
 	}
 
 	for k, v := range locations {
-		if v.datacenter == "" {
+		if v.Datacenter == "" {
 			return nil, fmt.Errorf("datacenter is required for location %s", k)
 		}
-		if v.datastore == "" {
+		if v.Datastore == "" {
 			return nil, fmt.Errorf("datastore is required for location %s", k)
 		}
-		if v.folder == "" {
+		if v.Folder == "" {
 			return nil, fmt.Errorf("folder is required for location %s", k)
 		}
-		if v.cluster == "" {
+		if v.Cluster == "" {
 			return nil, fmt.Errorf("cluster is required for location %s", k)
 		}
-		if v.resourcepool == "" {
+		if v.Resourcepool == "" {
 			return nil, fmt.Errorf("resourcepool is required for location %s", k)
 		}
-		locations[k].resourcepool = fmt.Sprintf("/%s/host/%s/%s", v.datacenter, v.cluster, v.resourcepool)
+		locations[k].Resourcepool = fmt.Sprintf("/%s/host/%s/%s", v.Datacenter, v.Cluster, v.Resourcepool)
 	}
 	return locations, nil
 }
@@ -366,14 +366,14 @@ func LoadCredentials(path string) (string, string, string, error) {
 	}
 
 	var creds struct {
-		vCenter  string `yaml:"vcenter"`
-		username string `yaml:"username"`
-		password string `yaml:"password"`
+		VCenter  string `yaml:"vcenter"`
+		Username string `yaml:"username"`
+		Password string `yaml:"password"`
 	}
 
 	if err := yaml.Unmarshal(file, &creds); err != nil {
 		return "", "", "", fmt.Errorf("failed to unmarshal credentials file:\n%w", err)
 	}
 
-	return creds.vCenter, creds.username, creds.password, nil
+	return creds.VCenter, creds.Username, creds.Password, nil
 }

--- a/vendir.yml
+++ b/vendir.yml
@@ -12,3 +12,5 @@ directories:
         - Chart.yaml
         - templates/manager/manager.yaml
         - templates/network-policy/network-policy.yaml
+        - templates/vsphere/credentials.yaml
+        - templates/vsphere/locations.yaml


### PR DESCRIPTION
https://github.com/giantswarm/roadmap/issues/2990

### What does this PR do?

- Adds deletion funcionality to the `vsphere` client
- Adds support for mutliple locations to the `vsphere` client
- Adds credential and location values management to the `vsphere` client
- Adds vsphere to the node image controller (== makes the operator sync images to vsphere)

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)
