### PR TITLE
Fix ova file name and ignore deprecated releases

### DIFF
--- a/internal/controller/release/release_controller.go
+++ b/internal/controller/release/release_controller.go
@@ -64,6 +64,12 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	flatcarChannel := "stable" // TODO: ensure that this is what it is supposed to be or if it comes from somewhere else
 
+	if release.Spec.State != "active" {
+		// Log that the release is deprecated and skipping it
+		log.Info("Release " + release.Name + " is deprecated - skipping")
+		return ctrl.Result{}, nil
+	}
+
 	nodeImage, err := image.GetNodeImageFromRelease(release, flatcarChannel)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -113,7 +113,10 @@ func getReleaseComponent(release *releases.Release, component string) (releases.
 }
 
 func GetImageKey(nodeImage *images.NodeImage) string {
-	return fmt.Sprintf("%s/%s-gs/%s.ova", nodeImage.Spec.Provider, nodeImage.Spec.Name, nodeImage.Spec.Name)
+	// the image name is like "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs"
+	// the ova file name is like "flatcar-stable-3975.2.0-kube-v1.30.4.ova"
+	ovaFileName := strings.Split(nodeImage.Spec.Name, "-tooling")[0]
+	return fmt.Sprintf("%s/%s-gs/%s.ova", nodeImage.Spec.Provider, nodeImage.Spec.Name, ovaFileName)
 }
 
 func getProviderFromProviderName(providerName string) string {

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -116,6 +116,8 @@ func GetImageKey(nodeImage *images.NodeImage) string {
 	// the image name is like "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs"
 	// the ova file name is like "flatcar-stable-3975.2.0-kube-v1.30.4.ova"
 	ovaFileName := strings.Split(nodeImage.Spec.Name, "-tooling")[0]
+	regexp := regexp.MustCompile(`(kube-)(\d+\.\d+\.\d+)`)
+	ovaFileName = regexp.ReplaceAllString(ovaFileName, `${1}v${2}`)
 	return fmt.Sprintf("%s/%s-gs/%s.ova", nodeImage.Spec.Provider, nodeImage.Spec.Name, ovaFileName)
 }
 


### PR DESCRIPTION
For reasons
The image name is like `flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs`
The ova file name is like `flatcar-stable-3975.2.0-kube-v1.30.4.ova`

Also the client will log `invalid URL` errors when trying to process `deprecated` releases.