### PR TITLE
add support for image suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `imagesuffix` to location field to set a suffix on the uploaded VM template name.
+
 ## [0.1.0] - 2025-03-27
 
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ vsphere:
       resourcepool: "my-resourcepool" # Optional
       host: "my-host" # Optional
       network: "my-network" # Optional
+      imagesuffix: "my-suffix" # Optional
 ```
 
 ## Getting Started

--- a/pkg/vsphere/client.go
+++ b/pkg/vsphere/client.go
@@ -30,6 +30,7 @@ type Location struct {
 	Resourcepool string `yaml:"resourcepool"`
 	Network      string `yaml:"network"`
 	Cluster      string `yaml:"cluster"`
+	ImageSuffix  string `yaml:"imagesuffix"`
 }
 
 // Config holds the configuration for the vSphere client
@@ -177,6 +178,11 @@ func (c *Client) Import(ctx context.Context, imageURL string, imageName string, 
 	network, err := c.getNetwork(ctx, c.Locations[loc].Network, finder)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get network: %w", err)
+	}
+
+	imageSuffix := c.Locations[loc].ImageSuffix
+	if len(imageSuffix) > 0 {
+		imageName = fmt.Sprintf("%s-%s", imageName, imageSuffix)
 	}
 
 	options := &importer.Options{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32952

tested in grouse (update depl tag, add location to cm, roll pod, profit).

Usage:

```yaml
data:
  locations: |-
    default:
      cluster: clu-prod
      datacenter: giant-swarm
      datastore: nfs_vm1
      folder: kube-templates
      imagesuffix: yolo
```