### PR TITLE
Fix all our problems with port 80 -__-

### DIFF
--- a/pkg/s3/client.go
+++ b/pkg/s3/client.go
@@ -103,11 +103,11 @@ func (c *Client) Pull(ctx context.Context, imageKey string) (string, error) {
 
 // GetURL returns the URL of an image in S3
 func (c *Client) GetURL(imageKey string) string {
-	return fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", c.bucketName, c.region, imageKey)
+	return fmt.Sprintf("http://%s.s3.%s.amazonaws.com/%s", c.bucketName, c.region, imageKey)
 }
 
 // IsS3URL checks if a URL is an S3 URL
 func IsS3URL(url string) bool {
-	regexp := regexp.MustCompile(`^https://[a-zA-Z0-9-]+\.s3\.[a-z0-9-]+\.amazonaws\.com/.+`)
+	regexp := regexp.MustCompile(`^http://[a-zA-Z0-9-]+\.s3\.[a-z0-9-]+\.amazonaws\.com/.+`)
 	return regexp.MatchString(url)
 }


### PR DESCRIPTION
By default, ESXi outbound traffic on port 443 is blocked in the OS firewall. 
We can't realistically make this a requirement for customers as node provisioning methods vary between IT teams and this will 100% get forgotten many times.
However, there is a default FW rule that allows outbound port 80 and the S3 bucket is accessible in HTTP.
In which case, the thumbprint can be set to anything.

I hate this so much...
