### PR TITLE
Add Proxmox provider for VM template creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add Proxmox provider support for image distribution.
+
 ## [0.8.0] - 2026-02-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,15 +81,68 @@ vcd:
     catalog: "my-catalog"
 ```
 
+### Proxmox Client
+The `image-controller` can create VM templates in one or more Proxmox VE nodes.
+It uses the Proxmox REST API exclusively (no SSH access required) to download qcow2 images
+from S3, create a VM, import the disk, convert it to a template, and tag it with component versions.
+
+The Proxmox API token must have the following permissions: `VM.*`, `Datastore.*`, `SDN.*`, `Sys.AccessNetwork`, `Sys.Audit` on `/`.
+
+The `local` storage (or whichever storage is used as `importStorage`) must have the `import` content type enabled.
+This can be done via the API (non-destructive, preserves existing content types):
+
+```
+PUT /api2/json/storage/local
+  content=backup,iso,vztmpl,import
+```
+
+The credentials and locations are specified inside the `values.yaml` file.
+
+```yaml
+proxmox:
+  credentials:
+    url: "proxmox.example.com:8006"
+    user: "my-user"
+    realm: "pve"       # defaults to "pam" if omitted
+    tokenId: "my-token"
+    secret: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    insecure: false     # set to true for self-signed certificates
+  locations:
+    location1:
+      node: "pve-node-1"
+      storagePool: "local-lvm"     # target storage for the VM disk
+      importStorage: "local"       # storage for downloaded images (defaults to "local")
+      bridge: "vmbr0"
+    location2:
+      node: "pve-node-2"
+      storagePool: "ceph-pool"
+      bridge: "vmbr1"
+```
+
+The template creation procedure follows these steps:
+1. Download the qcow2 from S3 to Proxmox import storage
+2. Allocate a VMID and create an empty VM
+3. Import the disk into the VM
+4. Set boot order and convert to template
+5. Tag the template with component versions (e.g. `flatcar_4459.2.4;kubernetes_1.34.5;os-tooling_v1.27.0;release-channel_stable`)
+6. Clean up the import file
+
+If any step fails, the operator performs best-effort cleanup of partial resources (VM, import file).
+
 ## Getting Started
 
 ### Network requirements
 
-#### Pull mode
+#### Proxmox
+
+The Proxmox node must have outbound HTTPS access to the S3 bucket to download images.
+The IDO pod must have access to the Proxmox API on port 8006.
+
+#### Pull mode (vSphere)
 
 The vSphere ESXi hosts must have access to the internet on port 443 (or 80, not preferred), this includes the vSphere firewall outgoing rules under `Hostname > Configure > System > Firewall > Outgoing > Edit > httpClient`.
 
-#### Push mode
+#### Push mode (vSphere)
 
 The IDO pod must have access to the IP of the vSphere ESXi hosts on port 443.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The template creation procedure follows these steps:
 2. Allocate a VMID and create an empty VM
 3. Import the disk into the VM
 4. Set boot order and convert to template
-5. Tag the template with component versions (e.g. `flatcar_4459.2.4;kubernetes_1.34.5;os-tooling_v1.27.0;release-channel_stable`)
+5. Tag the template with component versions (e.g. `flatcar_4459.2.4;kubernetes_1.34.5;os-tooling_1.27.0;release-channel_stable`)
 6. Clean up the import file
 
 If any step fails, the operator performs best-effort cleanup of partial resources (VM, import file).

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/giantswarm/image-distribution-operator/internal/controller/release"
 	clouddirector "github.com/giantswarm/image-distribution-operator/pkg/cloud-director"
 	"github.com/giantswarm/image-distribution-operator/pkg/provider"
+	"github.com/giantswarm/image-distribution-operator/pkg/proxmox"
 	"github.com/giantswarm/image-distribution-operator/pkg/s3"
 	"github.com/giantswarm/image-distribution-operator/pkg/vsphere"
 	// +kubebuilder:scaffold:imports
@@ -87,6 +88,9 @@ func main() {
 	var vcdLocations string
 	var vcdDownloadDir string
 
+	var proxmoxCredentials string
+	var proxmoxLocations string
+
 	var imageRetentionPeriod time.Duration
 
 	flag.StringVar(&namespace, "namespace", "giantswarm", "The namespace where node image objects are managed.")
@@ -107,6 +111,12 @@ func main() {
 		"The file containing the locations for VMware Cloud Director resources.")
 	flag.StringVar(&vcdDownloadDir, "vcd-download-dir", "/tmp/images",
 		"The directory where VCD images are downloaded.")
+
+	flag.StringVar(&proxmoxCredentials, "proxmox-credentials", "/home/.proxmox/credentials",
+		"The file containing the credentials for Proxmox resources.")
+	flag.StringVar(&proxmoxLocations, "proxmox-locations", "/home/.proxmox/locations",
+		"The file containing the locations for Proxmox resources.")
+
 	flag.DurationVar(&imageRetentionPeriod, "image-retention-period", 0,
 		"The duration for which unused images are retained before deletion.")
 
@@ -289,6 +299,21 @@ func main() {
 	} else {
 		providers["capvcd"] = vcdClient
 		setupLog.Info("Cloud Director provider initialized successfully", "provider", "capvcd")
+	}
+
+	// Try to initialize Proxmox provider
+	proxmoxClient, err := proxmox.New(proxmox.Config{
+		CredentialsFile: proxmoxCredentials,
+		LocationsFile:   proxmoxLocations,
+	}, context.Background())
+	if err != nil {
+		setupLog.Info(
+			"Proxmox provider not configured - will fail if NodeImage references 'capmox' provider",
+			"error", err,
+		)
+	} else {
+		providers["capmox"] = proxmoxClient
+		setupLog.Info("Proxmox provider initialized successfully", "provider", "capmox")
 	}
 
 	// Create a simpler map for ReleaseReconciler (just provider names)

--- a/helm/image-distribution-operator/templates/manager/manager.yaml
+++ b/helm/image-distribution-operator/templates/manager/manager.yaml
@@ -89,6 +89,16 @@ spec:
               name: vcd-locations
               subPath: locations
             {{- end }}
+            {{- if .Values.proxmox.credentials }}
+            - mountPath: /home/.proxmox/credentials
+              name: proxmox-credentials
+              subPath: credentials
+            {{- end }}
+            {{- if .Values.proxmox.locations }}
+            - mountPath: /home/.proxmox/locations
+              name: proxmox-locations
+              subPath: locations
+            {{- end }}
             {{- if and .Values.metrics.enable .Values.certmanager.enable }}
             - name: metrics-certs
               mountPath: /tmp/k8s-metrics-server/metrics-certs
@@ -120,6 +130,16 @@ spec:
         - name: vcd-locations
           configMap:
             name: image-distribution-operator-vcd-locations
+        {{- end }}
+        {{- if .Values.proxmox.credentials }}
+        - name: proxmox-credentials
+          secret:
+            secretName: image-distribution-operator-proxmox-credentials
+        {{- end }}
+        {{- if .Values.proxmox.locations }}
+        - name: proxmox-locations
+          configMap:
+            name: image-distribution-operator-proxmox-locations
         {{- end }}
         {{- if and .Values.metrics.enable .Values.certmanager.enable }}
         - name: metrics-certs

--- a/helm/image-distribution-operator/templates/proxmox/credentials.yaml
+++ b/helm/image-distribution-operator/templates/proxmox/credentials.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.proxmox.credentials }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: image-distribution-operator-proxmox-credentials
+  namespace: {{ .Release.Namespace }}
+stringData:
+  credentials: |-
+    {{- .Values.proxmox.credentials | toYaml | nindent 4 }}
+type: Opaque
+{{- end }}

--- a/helm/image-distribution-operator/templates/proxmox/locations.yaml
+++ b/helm/image-distribution-operator/templates/proxmox/locations.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.proxmox.locations }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: image-distribution-operator-proxmox-locations
+  namespace: {{ .Release.Namespace }}
+data:
+  locations: |-
+    {{- .Values.proxmox.locations | toYaml | nindent 4 }}
+{{- end }}

--- a/helm/image-distribution-operator/values.schema.json
+++ b/helm/image-distribution-operator/values.schema.json
@@ -260,6 +260,37 @@
                 }
             }
         },
+        "proxmox": {
+            "type": "object",
+            "properties": {
+                "credentials": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string"
+                        },
+                        "user": {
+                            "type": "string"
+                        },
+                        "realm": {
+                            "type": "string"
+                        },
+                        "tokenId": {
+                            "type": "string"
+                        },
+                        "secret": {
+                            "type": "string"
+                        },
+                        "insecure": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "locations": {
+                    "type": "object"
+                }
+            }
+        },
         "vsphere": {
             "type": "object",
             "properties": {

--- a/helm/image-distribution-operator/values.yaml
+++ b/helm/image-distribution-operator/values.yaml
@@ -101,6 +101,16 @@ vcd:
     vdc: ""
     catalog: ""
 
+proxmox:
+  credentials:
+    url: ""
+    user: ""
+    realm: "pam"
+    tokenId: ""
+    secret: ""
+    insecure: false
+  locations: {}
+
 s3:
   bucket: ""
   region: ""

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -114,6 +114,13 @@ func getReleaseComponent(release *releases.Release, component string) (releases.
 }
 
 func GetImageKey(nodeImage *images.NodeImage) string {
+	if nodeImage.Spec.Provider == "capmox" {
+		return getQcow2ImageKey(nodeImage)
+	}
+	return getOVAImageKey(nodeImage)
+}
+
+func getOVAImageKey(nodeImage *images.NodeImage) string {
 	// the image name is like "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs"
 	// the ova file name is like "flatcar-stable-3975.2.0-kube-v1.30.4.ova"
 	ovaFileName := strings.Split(nodeImage.Spec.Name, "-tooling")[0]
@@ -129,12 +136,24 @@ func GetImageKey(nodeImage *images.NodeImage) string {
 	return fmt.Sprintf("%s/%s/%s.ova", s3Provider, nodeImage.Spec.Name, ovaFileName)
 }
 
+func getQcow2ImageKey(nodeImage *images.NodeImage) string {
+	// the image name is like "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs"
+	// the qcow2 file name is like "flatcar-stable-3975.2.0-kube-v1.30.4.qcow2"
+	qcow2FileName := strings.Split(nodeImage.Spec.Name, "-tooling")[0]
+	regexp := regexp.MustCompile(`(kube-)(\d+\.\d+\.\d+)`)
+	qcow2FileName = regexp.ReplaceAllString(qcow2FileName, `${1}v${2}`)
+
+	return fmt.Sprintf("capmox/%s/%s.qcow2", nodeImage.Spec.Name, qcow2FileName)
+}
+
 func getProviderFromProviderName(providerName string) string {
 	switch providerName {
 	case "vsphere":
 		return "capv"
 	case "cloud-director":
 		return "capvcd"
+	case "proxmox":
+		return "capmox"
 	default:
 		return providerName
 	}

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -43,12 +43,18 @@ func TestGetImageProvider(t *testing.T) {
 			expectError:      false,
 		},
 		{
-			name:        "case 4: invalid release name without version",
+			name:             "case 4: proxmox release extracts proxmox provider",
+			releaseName:      "proxmox-1.2.3",
+			expectedProvider: "proxmox",
+			expectError:      false,
+		},
+		{
+			name:        "case 5: invalid release name without version",
 			releaseName: "vsphere",
 			expectError: true,
 		},
 		{
-			name:        "case 5: invalid release name with invalid format",
+			name:        "case 6: invalid release name with invalid format",
 			releaseName: "invalid-release-name",
 			expectError: true,
 		},
@@ -85,12 +91,17 @@ func TestGetProviderFromProviderName(t *testing.T) {
 			expectedProvider: "capvcd",
 		},
 		{
-			name:             "case 2: unknown provider returns same name",
+			name:             "case 2: proxmox maps to capmox",
+			providerName:     "proxmox",
+			expectedProvider: "capmox",
+		},
+		{
+			name:             "case 3: unknown provider returns same name",
 			providerName:     "aws",
 			expectedProvider: "aws",
 		},
 		{
-			name:             "case 3: test provider returns same name",
+			name:             "case 4: test provider returns same name",
 			providerName:     "test",
 			expectedProvider: "test",
 		},
@@ -155,7 +166,27 @@ func TestGetNodeImageFromRelease(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			name: "case 2: missing flatcar component returns error",
+			name: "case 2: proxmox release creates correct node image",
+			release: &releases.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "proxmox-1.2.3",
+				},
+				Spec: releases.ReleaseSpec{
+					Components: []releases.ReleaseSpecComponent{
+						{Name: "flatcar", Version: "3975.2.0"},
+						{Name: "kubernetes", Version: "v1.30.4"},
+						{Name: "os-tooling", Version: "v1.18.1"},
+					},
+				},
+			},
+			flatcarChannel:     "stable",
+			expectedImageName:  "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs",
+			expectedProvider:   "capmox",
+			expectedObjectName: "capmox-flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs",
+			expectError:        false,
+		},
+		{
+			name: "case 3: missing flatcar component returns error",
 			release: &releases.Release{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "vsphere-1.2.3",
@@ -171,7 +202,7 @@ func TestGetNodeImageFromRelease(t *testing.T) {
 			expectError:    true,
 		},
 		{
-			name: "case 3: missing kubernetes component returns error",
+			name: "case 4: missing kubernetes component returns error",
 			release: &releases.Release{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cloud-director-0.10.5",
@@ -233,7 +264,18 @@ func TestGetImageKey(t *testing.T) {
 				"flatcar-stable-3975.2.0-kube-v1.30.4.ova",
 		},
 		{
-			name: "case 2: image with different kubernetes version",
+			name: "case 2: proxmox/capmox node image generates correct qcow2 S3 key",
+			nodeImage: &images.NodeImage{
+				Spec: images.NodeImageSpec{
+					Name:     "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs",
+					Provider: "capmox",
+				},
+			},
+			expectedImageKey: "capmox/flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs/" +
+				"flatcar-stable-3975.2.0-kube-v1.30.4.qcow2",
+		},
+		{
+			name: "case 3: image with different kubernetes version",
 			nodeImage: &images.NodeImage{
 				Spec: images.NodeImageSpec{
 					Name:     "flatcar-stable-3975.2.0-kube-1.29.0-tooling-1.18.1-gs",

--- a/pkg/proxmox/client.go
+++ b/pkg/proxmox/client.go
@@ -1,0 +1,401 @@
+package proxmox
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Client wraps the Proxmox REST API client
+type Client struct {
+	baseURL    string
+	authHeader string
+	httpClient *http.Client
+	locations  map[string]*Location
+}
+
+// Credentials holds the authentication details for the Proxmox API
+type Credentials struct {
+	URL      string `yaml:"url"`      // e.g. "proxmox.example.com:8006"
+	User     string `yaml:"user"`     // e.g. "root"
+	Realm    string `yaml:"realm"`    // e.g. "pam" (defaults to "pam")
+	TokenID  string `yaml:"tokenId"`  // e.g. "mytoken"
+	Secret   string `yaml:"secret"`   // the API token secret
+	Insecure bool   `yaml:"insecure"` // skip TLS verification
+}
+
+// Location holds a single Proxmox location configuration
+type Location struct {
+	Node          string `yaml:"node"`          // Proxmox node name (e.g. "pve")
+	StoragePool   string `yaml:"storagePool"`   // target storage for VM disk (e.g. "local-lvm")
+	ImportStorage string `yaml:"importStorage"` // storage for downloaded images (defaults to "local")
+	Bridge        string `yaml:"bridge"`        // network bridge (e.g. "vmbr0")
+}
+
+// Config holds the configuration for the Proxmox client
+type Config struct {
+	CredentialsFile string
+	LocationsFile   string
+}
+
+// taskResponse represents the Proxmox task status API response
+type taskResponse struct {
+	Data struct {
+		Status     string `json:"status"`
+		ExitStatus string `json:"exitstatus"`
+	} `json:"data"`
+}
+
+// apiResponse represents a generic Proxmox API response with a data field
+type apiResponse struct {
+	Data json.RawMessage `json:"data"`
+}
+
+// resourceItem represents a single resource from the cluster resources API
+type resourceItem struct {
+	VMID     int    `json:"vmid"`
+	Name     string `json:"name"`
+	Node     string `json:"node"`
+	Template int    `json:"template"`
+	Type     string `json:"type"`
+}
+
+// New initializes a new Proxmox client
+func New(c Config, ctx context.Context) (*Client, error) {
+	log := log.FromContext(ctx)
+
+	creds, err := loadCredentials(c.CredentialsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load credentials:\n%w", err)
+	}
+
+	log.Info("Connecting to Proxmox", "url", creds.URL)
+
+	realm := creds.Realm
+	if realm == "" {
+		realm = "pam"
+	}
+
+	authHeader := fmt.Sprintf("PVEAPIToken=%s@%s!%s=%s", creds.User, realm, creds.TokenID, creds.Secret)
+	baseURL := fmt.Sprintf("https://%s/api2/json", creds.URL)
+
+	transport := &http.Transport{}
+	if creds.Insecure {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true, // #nosec G402 — user-configured for self-signed certs
+		}
+	}
+
+	httpClient := &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second,
+	}
+
+	locations, err := loadLocations(c.LocationsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load locations file:\n%w", err)
+	}
+
+	client := &Client{
+		baseURL:    baseURL,
+		authHeader: authHeader,
+		httpClient: httpClient,
+		locations:  locations,
+	}
+
+	// Validate connectivity
+	if _, err := client.doRequest(ctx, http.MethodGet, "/version", nil); err != nil {
+		return nil, fmt.Errorf("failed to connect to Proxmox API: %w", err)
+	}
+
+	log.Info("Successfully connected to Proxmox", "url", creds.URL)
+
+	return client, nil
+}
+
+// GetLocations returns all configured Proxmox locations
+func (c *Client) GetLocations() map[string]interface{} {
+	locations := make(map[string]interface{})
+	for k, v := range c.locations {
+		locations[k] = v
+	}
+	return locations
+}
+
+// Exists checks if a template with the given name already exists in Proxmox
+func (c *Client) Exists(ctx context.Context, name string, loc string) (bool, error) {
+	_, _, found, err := c.findVMByName(ctx, name)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if template exists: %w", err)
+	}
+	return found, nil
+}
+
+// Delete removes a template from Proxmox
+func (c *Client) Delete(ctx context.Context, name string, loc string) error {
+	log := log.FromContext(ctx)
+
+	vmid, node, found, err := c.findVMByName(ctx, name)
+	if err != nil {
+		return fmt.Errorf("failed to find template: %w", err)
+	}
+	if !found {
+		log.Info("Template not found, nothing to delete", "name", name)
+		return nil
+	}
+
+	path := fmt.Sprintf("/nodes/%s/qemu/%d", node, vmid)
+	params := url.Values{}
+	params.Set("purge", "1")
+
+	body, err := c.doRequest(ctx, http.MethodDelete, path+"?"+params.Encode(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete VM %d: %w", vmid, err)
+	}
+
+	upid, err := extractUPID(body)
+	if err != nil {
+		return fmt.Errorf("failed to extract UPID from delete response: %w", err)
+	}
+
+	if err := c.waitForTask(ctx, node, upid); err != nil {
+		return fmt.Errorf("delete task failed: %w", err)
+	}
+
+	log.Info("Deleted template", "name", name, "vmid", vmid)
+	return nil
+}
+
+// Create imports a qcow2 image and creates a VM template in Proxmox
+func (c *Client) Create(ctx context.Context, imageURL string, imageName string, loc string) error {
+	return c.createTemplate(ctx, imageURL, imageName, loc)
+}
+
+// doRequest executes an HTTP request against the Proxmox API
+func (c *Client) doRequest(ctx context.Context, method, path string, params url.Values) ([]byte, error) {
+	fullURL := c.baseURL + path
+
+	var bodyReader io.Reader
+	if params != nil && (method == http.MethodPost || method == http.MethodPut) {
+		bodyReader = strings.NewReader(params.Encode())
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", c.authHeader)
+	if bodyReader != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+// waitForTask polls a Proxmox task until completion
+func (c *Client) waitForTask(ctx context.Context, node string, upid string) error {
+	log := log.FromContext(ctx)
+
+	encodedUPID := url.PathEscape(upid)
+	path := fmt.Sprintf("/nodes/%s/tasks/%s/status", node, encodedUPID)
+
+	backoff := 2 * time.Second
+	maxBackoff := 30 * time.Second
+	timeout := 30 * time.Minute
+
+	deadline := time.Now().Add(timeout)
+
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("task timed out after %v: %s", timeout, upid)
+		}
+
+		body, err := c.doRequest(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return fmt.Errorf("failed to poll task status: %w", err)
+		}
+
+		var taskResp taskResponse
+		if err := json.Unmarshal(body, &taskResp); err != nil {
+			return fmt.Errorf("failed to parse task response: %w", err)
+		}
+
+		if taskResp.Data.Status == "stopped" {
+			if taskResp.Data.ExitStatus != "OK" {
+				// Fetch task log for error details
+				logPath := fmt.Sprintf("/nodes/%s/tasks/%s/log", node, encodedUPID)
+				logBody, logErr := c.doRequest(ctx, http.MethodGet, logPath, nil)
+				if logErr == nil {
+					log.Info("Task failed", "upid", upid, "exitstatus", taskResp.Data.ExitStatus, "log", string(logBody))
+				}
+				return fmt.Errorf("task failed with exit status: %s", taskResp.Data.ExitStatus)
+			}
+			return nil
+		}
+
+		log.V(1).Info("Task still running", "upid", upid, "status", taskResp.Data.Status)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+
+		backoff = backoff * 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// getNextVMID retrieves the next available VMID from Proxmox
+func (c *Client) getNextVMID(ctx context.Context) (int, error) {
+	body, err := c.doRequest(ctx, http.MethodGet, "/cluster/nextid", nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get next VMID: %w", err)
+	}
+
+	var resp apiResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return 0, fmt.Errorf("failed to parse next VMID response: %w", err)
+	}
+
+	// The data field is a string containing the VMID number
+	var vmidStr string
+	if err := json.Unmarshal(resp.Data, &vmidStr); err != nil {
+		// Try as integer directly
+		var vmid int
+		if err := json.Unmarshal(resp.Data, &vmid); err != nil {
+			return 0, fmt.Errorf("failed to parse VMID from response: %s", string(resp.Data))
+		}
+		return vmid, nil
+	}
+
+	var vmid int
+	if _, err := fmt.Sscanf(vmidStr, "%d", &vmid); err != nil {
+		return 0, fmt.Errorf("failed to parse VMID string %q: %w", vmidStr, err)
+	}
+
+	return vmid, nil
+}
+
+// findVMByName searches for a VM/template by name across the cluster
+func (c *Client) findVMByName(ctx context.Context, name string) (vmid int, node string, found bool, err error) {
+	body, err := c.doRequest(ctx, http.MethodGet, "/cluster/resources?type=vm", nil)
+	if err != nil {
+		return 0, "", false, fmt.Errorf("failed to list cluster resources: %w", err)
+	}
+
+	var resp struct {
+		Data []resourceItem `json:"data"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return 0, "", false, fmt.Errorf("failed to parse cluster resources: %w", err)
+	}
+
+	for _, item := range resp.Data {
+		if item.Name == name {
+			return item.VMID, item.Node, true, nil
+		}
+	}
+
+	return 0, "", false, nil
+}
+
+// extractUPID extracts the UPID string from a Proxmox API response
+func extractUPID(body []byte) (string, error) {
+	var resp apiResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	var upid string
+	if err := json.Unmarshal(resp.Data, &upid); err != nil {
+		return "", fmt.Errorf("failed to parse UPID from response: %s", string(resp.Data))
+	}
+
+	return upid, nil
+}
+
+func loadCredentials(path string) (*Credentials, error) {
+	file, err := os.ReadFile(path) // nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("failed to read credentials file:\n%w", err)
+	}
+
+	var creds Credentials
+	if err := yaml.Unmarshal(file, &creds); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal credentials file:\n%w", err)
+	}
+
+	if creds.URL == "" {
+		return nil, fmt.Errorf("url is required in credentials")
+	}
+	if creds.User == "" {
+		return nil, fmt.Errorf("user is required in credentials")
+	}
+	if creds.TokenID == "" {
+		return nil, fmt.Errorf("tokenId is required in credentials")
+	}
+	if creds.Secret == "" {
+		return nil, fmt.Errorf("secret is required in credentials")
+	}
+
+	return &creds, nil
+}
+
+func loadLocations(path string) (map[string]*Location, error) {
+	locations := make(map[string]*Location)
+
+	file, err := os.ReadFile(path) // nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("failed to read locations file:\n%w", err)
+	}
+
+	if err := yaml.Unmarshal(file, locations); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal locations file:\n%w", err)
+	}
+
+	for k, v := range locations {
+		if v.Node == "" {
+			return nil, fmt.Errorf("node is required for location %s", k)
+		}
+		if v.StoragePool == "" {
+			return nil, fmt.Errorf("storagePool is required for location %s", k)
+		}
+		if v.Bridge == "" {
+			return nil, fmt.Errorf("bridge is required for location %s", k)
+		}
+		if v.ImportStorage == "" {
+			locations[k].ImportStorage = "local"
+		}
+	}
+
+	return locations, nil
+}

--- a/pkg/proxmox/client_test.go
+++ b/pkg/proxmox/client_test.go
@@ -1,0 +1,564 @@
+package proxmox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildTags(t *testing.T) {
+	testCases := []struct {
+		name         string
+		imageName    string
+		expectedTags string
+	}{
+		{
+			name:         "case 0: standard image name",
+			imageName:    "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs",
+			expectedTags: "flatcar_3975.2.0;kubernetes_1.30.4;os-tooling_v1.18.1;release-channel_stable",
+		},
+		{
+			name:         "case 1: beta channel",
+			imageName:    "flatcar-beta-4459.2.4-kube-1.34.5-tooling-1.27.0-gs",
+			expectedTags: "flatcar_4459.2.4;kubernetes_1.34.5;os-tooling_v1.27.0;release-channel_beta",
+		},
+		{
+			name:         "case 2: invalid image name returns empty",
+			imageName:    "not-a-valid-image-name",
+			expectedTags: "",
+		},
+		{
+			name:         "case 3: empty image name returns empty",
+			imageName:    "",
+			expectedTags: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tags := buildTags(tc.imageName)
+			assert.Equal(t, tc.expectedTags, tags)
+		})
+	}
+}
+
+func TestLoadCredentials(t *testing.T) {
+	t.Run("valid credentials", func(t *testing.T) {
+		content := `url: "proxmox.example.com:8006"
+user: "root"
+realm: "pam"
+tokenId: "mytoken"
+secret: "mysecret"
+insecure: true`
+
+		path := writeTempFile(t, "creds-*.yaml", content)
+		creds, err := loadCredentials(path)
+		require.NoError(t, err)
+		assert.Equal(t, "proxmox.example.com:8006", creds.URL)
+		assert.Equal(t, "root", creds.User)
+		assert.Equal(t, "pam", creds.Realm)
+		assert.Equal(t, "mytoken", creds.TokenID)
+		assert.Equal(t, "mysecret", creds.Secret)
+		assert.True(t, creds.Insecure)
+	})
+
+	t.Run("missing url returns error", func(t *testing.T) {
+		content := `user: "root"
+tokenId: "mytoken"
+secret: "mysecret"`
+
+		path := writeTempFile(t, "creds-*.yaml", content)
+		_, err := loadCredentials(path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "url is required")
+	})
+
+	t.Run("missing user returns error", func(t *testing.T) {
+		content := `url: "proxmox.example.com:8006"
+tokenId: "mytoken"
+secret: "mysecret"`
+
+		path := writeTempFile(t, "creds-*.yaml", content)
+		_, err := loadCredentials(path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "user is required")
+	})
+
+	t.Run("missing tokenId returns error", func(t *testing.T) {
+		content := `url: "proxmox.example.com:8006"
+user: "root"
+secret: "mysecret"`
+
+		path := writeTempFile(t, "creds-*.yaml", content)
+		_, err := loadCredentials(path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "tokenId is required")
+	})
+
+	t.Run("missing secret returns error", func(t *testing.T) {
+		content := `url: "proxmox.example.com:8006"
+user: "root"
+tokenId: "mytoken"`
+
+		path := writeTempFile(t, "creds-*.yaml", content)
+		_, err := loadCredentials(path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "secret is required")
+	})
+
+	t.Run("file not found returns error", func(t *testing.T) {
+		_, err := loadCredentials("/nonexistent/path")
+		assert.Error(t, err)
+	})
+}
+
+func TestLoadLocations(t *testing.T) {
+	t.Run("valid locations", func(t *testing.T) {
+		content := `datacenter-1:
+  node: "pve-node-1"
+  storagePool: "local-lvm"
+  importStorage: "local"
+  bridge: "vmbr0"
+datacenter-2:
+  node: "pve-node-2"
+  storagePool: "ceph-pool"
+  bridge: "vmbr1"`
+
+		path := writeTempFile(t, "locs-*.yaml", content)
+		locations, err := loadLocations(path)
+		require.NoError(t, err)
+		assert.Len(t, locations, 2)
+
+		assert.Equal(t, "pve-node-1", locations["datacenter-1"].Node)
+		assert.Equal(t, "local-lvm", locations["datacenter-1"].StoragePool)
+		assert.Equal(t, "local", locations["datacenter-1"].ImportStorage)
+		assert.Equal(t, "vmbr0", locations["datacenter-1"].Bridge)
+
+		// ImportStorage should default to "local" when empty
+		assert.Equal(t, "local", locations["datacenter-2"].ImportStorage)
+	})
+
+	t.Run("missing node returns error", func(t *testing.T) {
+		content := `dc1:
+  storagePool: "local-lvm"
+  bridge: "vmbr0"`
+
+		path := writeTempFile(t, "locs-*.yaml", content)
+		_, err := loadLocations(path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "node is required")
+	})
+
+	t.Run("missing storagePool returns error", func(t *testing.T) {
+		content := `dc1:
+  node: "pve"
+  bridge: "vmbr0"`
+
+		path := writeTempFile(t, "locs-*.yaml", content)
+		_, err := loadLocations(path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "storagePool is required")
+	})
+
+	t.Run("missing bridge returns error", func(t *testing.T) {
+		content := `dc1:
+  node: "pve"
+  storagePool: "local-lvm"`
+
+		path := writeTempFile(t, "locs-*.yaml", content)
+		_, err := loadLocations(path)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "bridge is required")
+	})
+}
+
+func TestExtractUPID(t *testing.T) {
+	t.Run("valid UPID", func(t *testing.T) {
+		body := `{"data":"UPID:pve:00001234:00000000:12345678:download:local:root@pam:"}`
+		upid, err := extractUPID([]byte(body))
+		require.NoError(t, err)
+		assert.Equal(t, "UPID:pve:00001234:00000000:12345678:download:local:root@pam:", upid)
+	})
+
+	t.Run("invalid JSON returns error", func(t *testing.T) {
+		_, err := extractUPID([]byte("not json"))
+		assert.Error(t, err)
+	})
+}
+
+func TestFindVMByName(t *testing.T) {
+	t.Run("finds existing VM", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api2/json/cluster/resources", r.URL.Path)
+			assert.Equal(t, "vm", r.URL.Query().Get("type"))
+
+			resp := map[string]interface{}{
+				"data": []map[string]interface{}{
+					{"vmid": 100, "name": "other-vm", "node": "pve", "template": 0, "type": "qemu"},
+					{"vmid": 200, "name": "my-template", "node": "pve-2", "template": 1, "type": "qemu"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			baseURL:    server.URL + "/api2/json",
+			authHeader: "PVEAPIToken=test",
+			httpClient: server.Client(),
+		}
+
+		vmid, node, found, err := client.findVMByName(context.Background(), "my-template")
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, 200, vmid)
+		assert.Equal(t, "pve-2", node)
+	})
+
+	t.Run("VM not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := map[string]interface{}{
+				"data": []map[string]interface{}{
+					{"vmid": 100, "name": "other-vm", "node": "pve", "template": 0, "type": "qemu"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			baseURL:    server.URL + "/api2/json",
+			authHeader: "PVEAPIToken=test",
+			httpClient: server.Client(),
+		}
+
+		_, _, found, err := client.findVMByName(context.Background(), "nonexistent")
+		require.NoError(t, err)
+		assert.False(t, found)
+	})
+}
+
+func TestGetNextVMID(t *testing.T) {
+	t.Run("returns VMID as string", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api2/json/cluster/nextid", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":"100"}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			baseURL:    server.URL + "/api2/json",
+			authHeader: "PVEAPIToken=test",
+			httpClient: server.Client(),
+		}
+
+		vmid, err := client.getNextVMID(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, 100, vmid)
+	})
+
+	t.Run("returns VMID as integer", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":200}`))
+		}))
+		defer server.Close()
+
+		client := &Client{
+			baseURL:    server.URL + "/api2/json",
+			authHeader: "PVEAPIToken=test",
+			httpClient: server.Client(),
+		}
+
+		vmid, err := client.getNextVMID(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, 200, vmid)
+	})
+}
+
+func TestExists(t *testing.T) {
+	t.Run("returns true when template exists", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := map[string]interface{}{
+				"data": []map[string]interface{}{
+					{"vmid": 100, "name": "my-template", "node": "pve", "template": 1, "type": "qemu"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			baseURL:    server.URL + "/api2/json",
+			authHeader: "PVEAPIToken=test",
+			httpClient: server.Client(),
+		}
+
+		exists, err := client.Exists(context.Background(), "my-template", "dc1")
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("returns false when template not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := map[string]interface{}{"data": []map[string]interface{}{}}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			baseURL:    server.URL + "/api2/json",
+			authHeader: "PVEAPIToken=test",
+			httpClient: server.Client(),
+		}
+
+		exists, err := client.Exists(context.Background(), "nonexistent", "dc1")
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+}
+
+func TestCreateTemplate(t *testing.T) {
+	t.Run("happy path - full template creation", func(t *testing.T) {
+		var step atomic.Int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			switch {
+			// Step 1: Download image
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/storage/local/download-url"):
+				assert.Equal(t, "import", r.FormValue("content"))
+				assert.Contains(t, r.FormValue("filename"), ".qcow2")
+				step.Store(1)
+				_, _ = w.Write([]byte(`{"data":"UPID:pve:0001:0:1:download:local:root@pam:"}`))
+
+			// Step 2: Get next VMID
+			case r.Method == http.MethodGet && r.URL.Path == "/api2/json/cluster/nextid":
+				step.Store(2)
+				_, _ = w.Write([]byte(`{"data":"100"}`))
+
+			// Step 3: Create VM
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/qemu") && !strings.Contains(r.URL.Path, "/config"):
+				assert.Equal(t, "100", r.FormValue("vmid"))
+				assert.Equal(t, "2048", r.FormValue("memory"))
+				assert.Equal(t, "2", r.FormValue("cores"))
+				step.Store(3)
+				_, _ = w.Write([]byte(`{"data":"UPID:pve:0002:0:2:qmcreate:100:root@pam:"}`))
+
+			// Step 4: Import disk (POST to config)
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/config"):
+				assert.Contains(t, r.FormValue("scsi0"), "import-from=local:import/")
+				step.Store(4)
+				_, _ = w.Write([]byte(`{"data":"UPID:pve:0003:0:3:qmconfig:100:root@pam:"}`))
+
+			// Step 5+7: PUT config (boot order or tags)
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/config"):
+				if r.FormValue("boot") != "" {
+					assert.Equal(t, "order=scsi0", r.FormValue("boot"))
+					step.Store(5)
+				}
+				_, _ = w.Write([]byte(`{"data":null}`))
+
+			// Step 6: Convert to template
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/template"):
+				step.Store(6)
+				_, _ = w.Write([]byte(`{"data":"UPID:pve:0004:0:4:qmtemplate:100:root@pam:"}`))
+
+			// Task status polling - always return completed
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tasks/"):
+				if strings.HasSuffix(r.URL.Path, "/status") {
+					_, _ = w.Write([]byte(`{"data":{"status":"stopped","exitstatus":"OK"}}`))
+				} else {
+					_, _ = w.Write([]byte(`{"data":[]}`))
+				}
+
+			// Cleanup: delete import file
+			case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/storage/"):
+				_, _ = w.Write([]byte(`{"data":"UPID:pve:0005:0:5:imgdel:local:root@pam:"}`))
+
+			default:
+				t.Logf("Unhandled request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := &Client{
+			baseURL:    server.URL + "/api2/json",
+			authHeader: "PVEAPIToken=test",
+			httpClient: server.Client(),
+			locations: map[string]*Location{
+				"dc1": {
+					Node:          "pve",
+					StoragePool:   "local-lvm",
+					ImportStorage: "local",
+					Bridge:        "vmbr0",
+				},
+			},
+		}
+
+		err := client.createTemplate(
+			context.Background(),
+			"https://example.com/image.qcow2",
+			"flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs",
+			"dc1",
+		)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, int(step.Load()), 6, "should have reached at least step 6 (template conversion)")
+	})
+
+	t.Run("cleanup on VM creation failure", func(t *testing.T) {
+		var cleanupImportCalled atomic.Bool
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			switch {
+			// Download succeeds
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/download-url"):
+				_, _ = w.Write([]byte(`{"data":"UPID:pve:0001:0:1:download:local:root@pam:"}`))
+
+			// Task polling - always OK
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tasks/") && strings.HasSuffix(r.URL.Path, "/status"):
+				_, _ = w.Write([]byte(`{"data":{"status":"stopped","exitstatus":"OK"}}`))
+
+			// Get next VMID
+			case r.Method == http.MethodGet && r.URL.Path == "/api2/json/cluster/nextid":
+				_, _ = w.Write([]byte(`{"data":"100"}`))
+
+			// VM creation fails
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/qemu"):
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"errors":{"vmid":"VM 100 already exists"}}`))
+
+			// Cleanup: delete import file
+			case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/storage/"):
+				cleanupImportCalled.Store(true)
+				_, _ = w.Write([]byte(`{"data":"UPID:pve:0005:0:5:imgdel:local:root@pam:"}`))
+
+			default:
+				_, _ = w.Write([]byte(`{"data":null}`))
+			}
+		}))
+		defer server.Close()
+
+		client := &Client{
+			baseURL:    server.URL + "/api2/json",
+			authHeader: "PVEAPIToken=test",
+			httpClient: server.Client(),
+			locations: map[string]*Location{
+				"dc1": {
+					Node:          "pve",
+					StoragePool:   "local-lvm",
+					ImportStorage: "local",
+					Bridge:        "vmbr0",
+				},
+			},
+		}
+
+		err := client.createTemplate(
+			context.Background(),
+			"https://example.com/image.qcow2",
+			"flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs",
+			"dc1",
+		)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create VM")
+		assert.True(t, cleanupImportCalled.Load(), "should have cleaned up import file")
+	})
+}
+
+func TestDelete(t *testing.T) {
+	t.Run("deletes existing template", func(t *testing.T) {
+		var deleteCalled atomic.Bool
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			switch {
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/cluster/resources"):
+				resp := map[string]interface{}{
+					"data": []map[string]interface{}{
+						{"vmid": 100, "name": "my-template", "node": "pve", "template": 1, "type": "qemu"},
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+
+			case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/qemu/100"):
+				deleteCalled.Store(true)
+				_, _ = w.Write([]byte(`{"data":"UPID:pve:0001:0:1:qmdestroy:100:root@pam:"}`))
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tasks/") && strings.HasSuffix(r.URL.Path, "/status"):
+				_, _ = w.Write([]byte(`{"data":{"status":"stopped","exitstatus":"OK"}}`))
+			}
+		}))
+		defer server.Close()
+
+		client := &Client{
+			baseURL:    server.URL + "/api2/json",
+			authHeader: "PVEAPIToken=test",
+			httpClient: server.Client(),
+		}
+
+		err := client.Delete(context.Background(), "my-template", "dc1")
+		assert.NoError(t, err)
+		assert.True(t, deleteCalled.Load())
+	})
+
+	t.Run("noop when template not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			resp := map[string]interface{}{"data": []map[string]interface{}{}}
+			_ = json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		client := &Client{
+			baseURL:    server.URL + "/api2/json",
+			authHeader: "PVEAPIToken=test",
+			httpClient: server.Client(),
+		}
+
+		err := client.Delete(context.Background(), "nonexistent", "dc1")
+		assert.NoError(t, err)
+	})
+}
+
+func TestGetLocations(t *testing.T) {
+	client := &Client{
+		locations: map[string]*Location{
+			"dc1": {Node: "pve-1", StoragePool: "local-lvm", Bridge: "vmbr0", ImportStorage: "local"},
+			"dc2": {Node: "pve-2", StoragePool: "ceph", Bridge: "vmbr1", ImportStorage: "local"},
+		},
+	}
+
+	locations := client.GetLocations()
+	assert.Len(t, locations, 2)
+	assert.NotNil(t, locations["dc1"])
+	assert.NotNil(t, locations["dc2"])
+}
+
+func writeTempFile(t *testing.T, pattern string, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, fmt.Sprintf("test-%s", pattern))
+	err := os.WriteFile(path, []byte(content), 0600)
+	require.NoError(t, err)
+	return path
+}

--- a/pkg/proxmox/client_test.go
+++ b/pkg/proxmox/client_test.go
@@ -25,12 +25,12 @@ func TestBuildTags(t *testing.T) {
 		{
 			name:         "case 0: standard image name",
 			imageName:    "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs",
-			expectedTags: "flatcar_3975.2.0;kubernetes_1.30.4;os-tooling_v1.18.1;release-channel_stable",
+			expectedTags: "flatcar_3975.2.0;kubernetes_1.30.4;os-tooling_1.18.1;release-channel_stable",
 		},
 		{
 			name:         "case 1: beta channel",
 			imageName:    "flatcar-beta-4459.2.4-kube-1.34.5-tooling-1.27.0-gs",
-			expectedTags: "flatcar_4459.2.4;kubernetes_1.34.5;os-tooling_v1.27.0;release-channel_beta",
+			expectedTags: "flatcar_4459.2.4;kubernetes_1.34.5;os-tooling_1.27.0;release-channel_beta",
 		},
 		{
 			name:         "case 2: invalid image name returns empty",

--- a/pkg/proxmox/import.go
+++ b/pkg/proxmox/import.go
@@ -1,0 +1,260 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// createTemplate orchestrates the full Proxmox template creation procedure:
+// 1. Download qcow2 from S3 to Proxmox import storage
+// 2. Create an empty VM
+// 3. Import the disk into the VM
+// 4. Set boot order
+// 5. Convert to template
+// 6. Set tags
+// 7. Clean up the import file
+func (c *Client) createTemplate(ctx context.Context, imageURL string, imageName string, loc string) error {
+	log := log.FromContext(ctx)
+
+	location := c.locations[loc]
+	node := location.Node
+	importStorage := location.ImportStorage
+	storagePool := location.StoragePool
+	bridge := location.Bridge
+
+	filename := imageName + ".qcow2"
+
+	var vmid int
+	var vmCreated bool
+	var imageDownloaded bool
+
+	// Step 1: Download the qcow2 from S3 to Proxmox import storage
+	log.Info("Downloading image to Proxmox import storage", "url", imageURL, "filename", filename, "node", node)
+	{
+		params := url.Values{}
+		params.Set("content", "import")
+		params.Set("filename", filename)
+		params.Set("url", imageURL)
+
+		path := fmt.Sprintf("/nodes/%s/storage/%s/download-url", node, importStorage)
+		body, err := c.doRequest(ctx, http.MethodPost, path, params)
+		if err != nil {
+			return fmt.Errorf("failed to start image download: %w", err)
+		}
+
+		upid, err := extractUPID(body)
+		if err != nil {
+			return fmt.Errorf("failed to extract UPID from download response: %w", err)
+		}
+
+		if err := c.waitForTask(ctx, node, upid); err != nil {
+			return fmt.Errorf("image download failed: %w", err)
+		}
+		imageDownloaded = true
+	}
+	log.Info("Image downloaded to import storage", "filename", filename)
+
+	// Step 2: Get next available VMID
+	vmid, err := c.getNextVMID(ctx)
+	if err != nil {
+		c.cleanup(ctx, node, 0, filename, importStorage)
+		return fmt.Errorf("failed to get next VMID: %w", err)
+	}
+	log.Info("Allocated VMID", "vmid", vmid)
+
+	// Step 3: Create an empty VM
+	{
+		params := url.Values{}
+		params.Set("vmid", fmt.Sprintf("%d", vmid))
+		params.Set("name", imageName)
+		params.Set("memory", "2048")
+		params.Set("cores", "2")
+		params.Set("scsihw", "virtio-scsi-pci")
+		params.Set("bios", "seabios")
+		params.Set("agent", "1")
+		params.Set("net0", fmt.Sprintf("e1000,bridge=%s", bridge))
+
+		path := fmt.Sprintf("/nodes/%s/qemu", node)
+		body, err := c.doRequest(ctx, http.MethodPost, path, params)
+		if err != nil {
+			c.cleanup(ctx, node, 0, filename, importStorage)
+			return fmt.Errorf("failed to create VM: %w", err)
+		}
+
+		upid, err := extractUPID(body)
+		if err != nil {
+			c.cleanup(ctx, node, 0, filename, importStorage)
+			return fmt.Errorf("failed to extract UPID from VM creation response: %w", err)
+		}
+
+		if err := c.waitForTask(ctx, node, upid); err != nil {
+			c.cleanup(ctx, node, 0, filename, importStorage)
+			return fmt.Errorf("VM creation failed: %w", err)
+		}
+		vmCreated = true
+	}
+	log.Info("Created empty VM", "vmid", vmid, "name", imageName)
+
+	// Step 4: Import the disk into the VM
+	// Important: Must use POST not PUT — POST runs as a background task which is required for disk import
+	{
+		params := url.Values{}
+		params.Set("scsi0", fmt.Sprintf("%s:0,import-from=%s:import/%s", storagePool, importStorage, filename))
+
+		path := fmt.Sprintf("/nodes/%s/qemu/%d/config", node, vmid)
+		body, err := c.doRequest(ctx, http.MethodPost, path, params)
+		if err != nil {
+			c.cleanup(ctx, node, vmid, filename, importStorage)
+			return fmt.Errorf("failed to start disk import: %w", err)
+		}
+
+		upid, err := extractUPID(body)
+		if err != nil {
+			c.cleanup(ctx, node, vmid, filename, importStorage)
+			return fmt.Errorf("failed to extract UPID from disk import response: %w", err)
+		}
+
+		if err := c.waitForTask(ctx, node, upid); err != nil {
+			c.cleanup(ctx, node, vmid, filename, importStorage)
+			return fmt.Errorf("disk import failed: %w", err)
+		}
+	}
+	log.Info("Imported disk into VM", "vmid", vmid)
+
+	// Step 5: Set boot order
+	{
+		params := url.Values{}
+		params.Set("boot", "order=scsi0")
+
+		path := fmt.Sprintf("/nodes/%s/qemu/%d/config", node, vmid)
+		if _, err := c.doRequest(ctx, http.MethodPut, path, params); err != nil {
+			c.cleanup(ctx, node, vmid, filename, importStorage)
+			return fmt.Errorf("failed to set boot order: %w", err)
+		}
+	}
+	log.Info("Set boot order", "vmid", vmid)
+
+	// Step 6: Convert to template
+	{
+		path := fmt.Sprintf("/nodes/%s/qemu/%d/template", node, vmid)
+		body, err := c.doRequest(ctx, http.MethodPost, path, nil)
+		if err != nil {
+			c.cleanup(ctx, node, vmid, filename, importStorage)
+			return fmt.Errorf("failed to convert VM to template: %w", err)
+		}
+
+		upid, err := extractUPID(body)
+		if err != nil {
+			c.cleanup(ctx, node, vmid, filename, importStorage)
+			return fmt.Errorf("failed to extract UPID from template conversion response: %w", err)
+		}
+
+		if err := c.waitForTask(ctx, node, upid); err != nil {
+			c.cleanup(ctx, node, vmid, filename, importStorage)
+			return fmt.Errorf("template conversion failed: %w", err)
+		}
+	}
+	log.Info("Converted VM to template", "vmid", vmid)
+
+	// Step 7: Set tags
+	tags := buildTags(imageName)
+	if tags != "" {
+		params := url.Values{}
+		params.Set("tags", tags)
+
+		path := fmt.Sprintf("/nodes/%s/qemu/%d/config", node, vmid)
+		if _, err := c.doRequest(ctx, http.MethodPut, path, params); err != nil {
+			// Tags are non-critical — log but don't fail
+			log.Info("Failed to set tags on template", "vmid", vmid, "error", err)
+		} else {
+			log.Info("Set tags on template", "vmid", vmid, "tags", tags)
+		}
+	}
+
+	// Step 8: Clean up the import file
+	c.cleanupImportFile(ctx, node, filename, importStorage)
+
+	_ = vmCreated
+	_ = imageDownloaded
+
+	log.Info("Template creation completed", "name", imageName, "vmid", vmid, "node", node)
+	return nil
+}
+
+// cleanup performs best-effort cleanup of partial resources on failure
+func (c *Client) cleanup(ctx context.Context, node string, vmid int, filename string, importStorage string) {
+	log := log.FromContext(ctx)
+
+	if vmid > 0 {
+		log.Info("Cleaning up: deleting VM", "vmid", vmid)
+		path := fmt.Sprintf("/nodes/%s/qemu/%d", node, vmid)
+		params := url.Values{}
+		params.Set("purge", "1")
+		body, err := c.doRequest(ctx, http.MethodDelete, path+"?"+params.Encode(), nil)
+		if err != nil {
+			log.Info("Cleanup: failed to delete VM", "vmid", vmid, "error", err)
+		} else if upid, err := extractUPID(body); err == nil {
+			if err := c.waitForTask(ctx, node, upid); err != nil {
+				log.Info("Cleanup: VM deletion task failed", "vmid", vmid, "error", err)
+			}
+		}
+	}
+
+	c.cleanupImportFile(ctx, node, filename, importStorage)
+}
+
+// cleanupImportFile removes the downloaded import file from Proxmox storage
+func (c *Client) cleanupImportFile(ctx context.Context, node string, filename string, importStorage string) {
+	log := log.FromContext(ctx)
+
+	log.Info("Cleaning up import file", "filename", filename)
+	path := fmt.Sprintf("/nodes/%s/storage/%s/content/%s:import/%s", node, importStorage, importStorage, filename)
+	body, err := c.doRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		log.Info("Cleanup: failed to delete import file", "filename", filename, "error", err)
+		return
+	}
+
+	upid, err := extractUPID(body)
+	if err != nil {
+		log.Info("Cleanup: failed to extract UPID from import file deletion", "error", err)
+		return
+	}
+
+	if err := c.waitForTask(ctx, node, upid); err != nil {
+		log.Info("Cleanup: import file deletion task failed", "filename", filename, "error", err)
+	}
+}
+
+// buildTags constructs Proxmox-compatible tags from an image name.
+// Input:  "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs"
+// Output: "flatcar_3975.2.0;kubernetes_1.30.4;os-tooling_v1.18.1;release-channel_stable"
+func buildTags(imageName string) string {
+	re := regexp.MustCompile(
+		`^flatcar-([a-z]+)-([0-9.]+)-kube-([0-9.]+)-tooling-([0-9.]+)-gs$`,
+	)
+	matches := re.FindStringSubmatch(imageName)
+	if len(matches) != 5 {
+		return ""
+	}
+
+	channel := matches[1]
+	flatcarVersion := matches[2]
+	kubeVersion := matches[3]
+	toolingVersion := matches[4]
+
+	tags := []string{
+		fmt.Sprintf("flatcar_%s", flatcarVersion),
+		fmt.Sprintf("kubernetes_%s", kubeVersion),
+		fmt.Sprintf("os-tooling_v%s", toolingVersion),
+		fmt.Sprintf("release-channel_%s", channel),
+	}
+
+	return strings.Join(tags, ";")
+}

--- a/pkg/proxmox/import.go
+++ b/pkg/proxmox/import.go
@@ -234,7 +234,7 @@ func (c *Client) cleanupImportFile(ctx context.Context, node string, filename st
 
 // buildTags constructs Proxmox-compatible tags from an image name.
 // Input:  "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs"
-// Output: "flatcar_3975.2.0;kubernetes_1.30.4;os-tooling_v1.18.1;release-channel_stable"
+// Output: "flatcar_3975.2.0;kubernetes_1.30.4;os-tooling_1.18.1;release-channel_stable"
 func buildTags(imageName string) string {
 	re := regexp.MustCompile(
 		`^flatcar-([a-z]+)-([0-9.]+)-kube-([0-9.]+)-tooling-([0-9.]+)-gs$`,
@@ -252,7 +252,7 @@ func buildTags(imageName string) string {
 	tags := []string{
 		fmt.Sprintf("flatcar_%s", flatcarVersion),
 		fmt.Sprintf("kubernetes_%s", kubeVersion),
-		fmt.Sprintf("os-tooling_v%s", toolingVersion),
+		fmt.Sprintf("os-tooling_%s", toolingVersion),
 		fmt.Sprintf("release-channel_%s", channel),
 	}
 


### PR DESCRIPTION
## Summary
- Add new Proxmox provider (`capmox`) that creates VM templates via the Proxmox REST API (no SSH required)
- Implements the full template creation procedure: download qcow2 from S3 → create VM → import disk → set boot order → convert to template → tag → cleanup
- Integrates with existing operator architecture: provider interface, release controller mapping (`proxmox` → `capmox`), S3 image key generation for qcow2 format
- Includes Helm chart support (credentials Secret, locations ConfigMap, volume mounts)

## Changes
- **New**: `pkg/proxmox/` — client, import logic, and tests (28 unit tests with mocked HTTP)
- **Modified**: `pkg/image/image.go` — provider name mapping + qcow2 S3 key generation
- **Modified**: `cmd/main.go` — CLI flags and provider registration
- **Modified**: Helm chart — templates, values, and deployment volumes for Proxmox
- **Modified**: `README.md` — Proxmox documentation

## Test plan
- [x] `go build ./cmd/... ./pkg/proxmox/... ./pkg/image/...` compiles clean
- [x] `go test ./pkg/image/...` — all tests pass (including new capmox cases)
- [x] `go test ./pkg/proxmox/...` — all 28 tests pass (mocked Proxmox API)
- [x] `go vet` — no issues
- [x] End-to-end: ran operator locally against a real cluster + Proxmox VE 9.1, template created successfully from `proxmox-34.1.0` Release CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)