### PR TITLE
fix(api): Register `metav1` types for the `image.giantswarm.io/v1alpha1` group in the scheme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update module github.com/aws/aws-sdk-go-v2/service/s3 to v1.102.0.
 - Update aws-sdk-go-v2 monorepo.
 - Go: Update dependencies.
+- API: Register `metav1` types for the `image.giantswarm.io/v1alpha1` group in the scheme.
 
 ## [0.11.0] - 2026-05-22
 

--- a/api/image/v1alpha1/nodeimage_types.go
+++ b/api/image/v1alpha1/nodeimage_types.go
@@ -85,6 +85,7 @@ type NodeImageList struct {
 func init() {
 	SchemeBuilder.Register(func(s *runtime.Scheme) error {
 		s.AddKnownTypes(GroupVersion, &NodeImage{}, &NodeImageList{})
+		metav1.AddToGroupVersion(s, GroupVersion)
 		return nil
 	})
 }


### PR DESCRIPTION
Fixes the following error message I encountered on a CAPV E2E MC:

```
2026-06-02T08:23:51Z	ERROR	controller-runtime.cache.UnhandledError	Failed to watch	{"reflector": "pkg/mod/k8s.io/client-go@v0.36.1/tools/cache/reflector.go:343", "type": "*v1alpha1.NodeImage", "error": "failed to list *v1alpha1.NodeImage: v1.ListOptions is not suitable for converting to \"image.giantswarm.io/v1alpha1\" in scheme \"pkg/runtime/scheme.go:111\""}
k8s.io/apimachinery/pkg/util/runtime.logError
	/go/pkg/mod/k8s.io/apimachinery@v0.36.1/pkg/util/runtime/runtime.go:252
k8s.io/apimachinery/pkg/util/runtime.handleError
	/go/pkg/mod/k8s.io/apimachinery@v0.36.1/pkg/util/runtime/runtime.go:243
k8s.io/apimachinery/pkg/util/runtime.HandleErrorWithContext
	/go/pkg/mod/k8s.io/apimachinery@v0.36.1/pkg/util/runtime/runtime.go:229
k8s.io/client-go/tools/cache.DefaultWatchErrorHandler
	/go/pkg/mod/k8s.io/client-go@v0.36.1/tools/cache/reflector.go:227
k8s.io/client-go/tools/cache.(*Reflector).RunWithContext.func1
	/go/pkg/mod/k8s.io/client-go@v0.36.1/tools/cache/reflector.go:430
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.36.1/pkg/util/wait/loop.go:53
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext
	/go/pkg/mod/k8s.io/apimachinery@v0.36.1/pkg/util/wait/loop.go:54
k8s.io/apimachinery/pkg/util/wait.DelayFunc.Until
	/go/pkg/mod/k8s.io/apimachinery@v0.36.1/pkg/util/wait/delay.go:39
k8s.io/client-go/tools/cache.(*Reflector).RunWithContext
	/go/pkg/mod/k8s.io/client-go@v0.36.1/tools/cache/reflector.go:428
k8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3
	/go/pkg/mod/k8s.io/apimachinery@v0.36.1/pkg/util/wait/wait.go:63
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.36.1/pkg/util/wait/wait.go:72
```

Thanks, Claude!