### PR TITLE
build: Extend Renovate config with GS golang config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update aws-sdk-go-v2 monorepo.
 - Go: Update dependencies.
 - API: Register `metav1` types for the `image.giantswarm.io/v1alpha1` group in the scheme.
+- Extend Renovate config with GS golang config.
 
 ## [0.11.0] - 2026-05-22
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,5 +2,7 @@
   "extends": [
     // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
+    // Go specific config - https://github.com/giantswarm/renovate-presets/blob/main/lang-go.json5
+    "github>giantswarm/renovate-presets:lang-go.json5",
   ],
 }


### PR DESCRIPTION
### What does this PR do?

- Pulls in golang-specific Renovate config, primarily to ensure `go mod tidy` is run for all golang dependency PRs.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
