### PR TITLE
build: Remove build steps from Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
       - architect/go-build:
           context: architect
           name: go-build
-          binary: template
+          binary: manager
           path: ./cmd
           filters:
             # Trigger job also on git tag.

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Prepare kubebuilder
         run: |
           go mod tidy
-          docker build -t kubebuilder:v0.1.0 .
+          docker build -f Dockerfile.local -t kubebuilder:v0.1.0 .
           kind load docker-image kubebuilder:v0.1.0
 
       - name: Install Helm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove superfluous build steps from the Dockerfile.
+- Add a Dockerfile for local development and testing.
+
 ## [0.11.1] - 2026-06-02
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,11 @@
-# Build the manager binary
-FROM docker.io/golang:1.26 AS builder
-ARG TARGETOS
-ARG TARGETARCH
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY cmd/main.go cmd/main.go
-COPY internal/ internal/
-COPY pkg/ pkg/
-COPY api/ api/
-
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
-
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/manager .
+
+ARG TARGETOS
+ARG TARGETARCH
+COPY manager-${TARGETOS}-${TARGETARCH} /manager
+
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,36 @@
+# This Dockerfile can be used to build a local image for testing purposes. It is not used by CI to build images which are pushed to a registry.
+
+# Build the manager binary
+FROM docker.io/golang:1.26 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/main.go cmd/main.go
+COPY internal/ internal/
+COPY pkg/ pkg/
+COPY api/ api/
+
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
### What does this PR do?

- Removes the build steps from the Dockerfile as these are already executed in the go-build step in the CircleCI workflow.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
