### PR TITLE
feat: split China registry push to its own job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ workflows:
       - architect/push-to-registries:
           context: architect
           name: push-to-registries
+          split-china-push: true
           requires:
             - go-build
           filters:
@@ -28,6 +29,17 @@ workflows:
               ignore:
                 - main
                 - master
+      - architect/sync-china-registry:
+          context: architect
+          name: sync-china-registry
+          requires:
+            - go-build
+            - push-to-registries
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /^.*$/
       - architect/push-to-app-catalog:
           context: architect
           executor: app-build-suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Split China registry push to its own job.
+
 ## [0.12.0] - 2026-06-25
 
 ### Changed


### PR DESCRIPTION
### What does this PR do?

uses the new china push method as described here https://intranet.giantswarm.io/docs/dev-and-releng/container-registry/split-china-push/

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
