### PR TITLE
add session refresh to vcd client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Refresh the Cloud Director session proactively before it expires, and retry once on a stale-session error, instead of failing every reconcile with a misleading "entity not found" error until the operator is restarted. The refresh threshold is configurable via `--vcd-session-refresh-threshold` / `vcd.sessionRefreshThreshold`, defaulting to 20h.
+
 ### Changed
 
 - Update module github.com/vmware/govmomi to v0.55.0.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -95,6 +95,7 @@ func main() {
 	var vcdCredentials string
 	var vcdLocations string
 	var vcdDownloadDir string
+	var vcdSessionRefreshThreshold time.Duration
 
 	var proxmoxCredentials string
 	var proxmoxLocations string
@@ -129,6 +130,8 @@ func main() {
 		"The file containing the locations for VMware Cloud Director resources.")
 	flag.StringVar(&vcdDownloadDir, "vcd-download-dir", "/tmp/images",
 		"The directory where VCD images are downloaded.")
+	flag.DurationVar(&vcdSessionRefreshThreshold, "vcd-session-refresh-threshold", 20*time.Hour,
+		"The age at which the Cloud Director session is proactively refreshed. Should be kept below VCD's session lifetime.")
 
 	flag.StringVar(&proxmoxCredentials, "proxmox-credentials", "/home/.proxmox/credentials",
 		"The file containing the credentials for Proxmox resources.")
@@ -321,10 +324,11 @@ func main() {
 
 		// Try to initialize Cloud Director provider
 		vcdClient, err := clouddirector.New(clouddirector.Config{
-			CredentialsFile: vcdCredentials,
-			LocationsFile:   vcdLocations,
-			DownloadDir:     vcdDownloadDir,
-			Backoff:         backoff,
+			CredentialsFile:         vcdCredentials,
+			LocationsFile:           vcdLocations,
+			DownloadDir:             vcdDownloadDir,
+			SessionRefreshThreshold: vcdSessionRefreshThreshold,
+			Backoff:                 backoff,
 		}, context.Background())
 		if err != nil {
 			setupLog.Info(

--- a/helm/image-distribution-operator/templates/manager/manager.yaml
+++ b/helm/image-distribution-operator/templates/manager/manager.yaml
@@ -42,6 +42,9 @@ spec:
             {{- if .Values.vcd.downloadDir }}
             - --vcd-download-dir={{ .Values.vcd.downloadDir }}
             {{- end }}
+            {{- if .Values.vcd.sessionRefreshThreshold }}
+            - --vcd-session-refresh-threshold={{ .Values.vcd.sessionRefreshThreshold }}
+            {{- end }}
             {{- if .Values.imageRetentionPeriod }}
             - --image-retention-period={{ .Values.imageRetentionPeriod }}
             {{- end }}

--- a/helm/image-distribution-operator/values.schema.json
+++ b/helm/image-distribution-operator/values.schema.json
@@ -275,6 +275,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "sessionRefreshThreshold": {
+                    "type": "string"
                 }
             }
         },

--- a/helm/image-distribution-operator/values.yaml
+++ b/helm/image-distribution-operator/values.yaml
@@ -98,6 +98,9 @@ vsphere:
 
 vcd:
   downloadDir: "/tmp/images"
+  # The age at which the Cloud Director session is proactively refreshed.
+  # Should be kept below VCD's session lifetime.
+  sessionRefreshThreshold: "20h"
   credentials:
     url: ""
     username: ""

--- a/pkg/cloud-director/client.go
+++ b/pkg/cloud-director/client.go
@@ -14,20 +14,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// sessionRefreshThreshold is kept comfortably under Cloud Director's observed
-// ~24h absolute session lifetime, so sessions get refreshed before they can
-// expire mid-reconcile.
-const sessionRefreshThreshold = 20 * time.Hour
+// defaultSessionRefreshThreshold is kept comfortably under Cloud Director's
+// observed ~24h absolute session lifetime, so sessions get refreshed before
+// they can expire mid-reconcile. Used when Config.SessionRefreshThreshold is
+// left unset.
+const defaultSessionRefreshThreshold = 20 * time.Hour
 
 // Client wraps the govcd client
 type Client struct {
-	cloudDirector   *govcd.VCDClient
-	url             string
-	location        *Location
-	downloadDir     string
-	credentials     *Credentials
-	backoff         wait.Backoff
-	authenticatedAt time.Time
+	cloudDirector           *govcd.VCDClient
+	url                     string
+	location                *Location
+	downloadDir             string
+	credentials             *Credentials
+	backoff                 wait.Backoff
+	authenticatedAt         time.Time
+	sessionRefreshThreshold time.Duration
 }
 
 type Credentials struct {
@@ -49,10 +51,11 @@ type Location struct {
 
 // Config holds the configuration for the cloudDirector client
 type Config struct {
-	Backoff         wait.Backoff
-	CredentialsFile string
-	LocationsFile   string
-	DownloadDir     string
+	Backoff                 wait.Backoff
+	CredentialsFile         string
+	LocationsFile           string
+	DownloadDir             string
+	SessionRefreshThreshold time.Duration
 }
 
 // New initializes a new cloudDirector client
@@ -77,13 +80,19 @@ func New(c Config, ctx context.Context) (*Client, error) {
 	}
 	location.Org = creds.Org
 
+	sessionRefreshThreshold := c.SessionRefreshThreshold
+	if sessionRefreshThreshold <= 0 {
+		sessionRefreshThreshold = defaultSessionRefreshThreshold
+	}
+
 	client := &Client{
-		cloudDirector: govcd.NewVCDClient(*u, creds.Insecure),
-		url:           creds.URL,
-		location:      location,
-		downloadDir:   c.DownloadDir,
-		credentials:   creds,
-		backoff:       c.Backoff,
+		cloudDirector:           govcd.NewVCDClient(*u, creds.Insecure),
+		url:                     creds.URL,
+		location:                location,
+		downloadDir:             c.DownloadDir,
+		credentials:             creds,
+		backoff:                 c.Backoff,
+		sessionRefreshThreshold: sessionRefreshThreshold,
 	}
 
 	if err := client.authenticate(ctx); err != nil {
@@ -126,7 +135,7 @@ func (c *Client) authenticate(ctx context.Context) error {
 // is old enough that it may have expired, so callers never have to deal with
 // a stale session themselves.
 func (c *Client) ensureSession(ctx context.Context) error {
-	if time.Since(c.authenticatedAt) < sessionRefreshThreshold {
+	if time.Since(c.authenticatedAt) < c.sessionRefreshThreshold {
 		return nil
 	}
 

--- a/pkg/cloud-director/client.go
+++ b/pkg/cloud-director/client.go
@@ -2,9 +2,11 @@ package clouddirector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/vmware/go-vcloud-director/v3/govcd"
 	"gopkg.in/yaml.v3"
@@ -12,12 +14,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// sessionRefreshThreshold is kept comfortably under Cloud Director's observed
+// ~24h absolute session lifetime, so sessions get refreshed before they can
+// expire mid-reconcile.
+const sessionRefreshThreshold = 20 * time.Hour
+
 // Client wraps the govcd client
 type Client struct {
-	cloudDirector *govcd.VCDClient
-	url           string
-	location      *Location
-	downloadDir   string
+	cloudDirector   *govcd.VCDClient
+	url             string
+	location        *Location
+	downloadDir     string
+	credentials     *Credentials
+	backoff         wait.Backoff
+	authenticatedAt time.Time
 }
 
 type Credentials struct {
@@ -61,12 +71,38 @@ func New(c Config, ctx context.Context) (*Client, error) {
 		return nil, fmt.Errorf("unable to parse URL: %w", err)
 	}
 
-	var lastErr error
-	vcdClient := govcd.NewVCDClient(*u, creds.Insecure)
+	location, err := loadLocation(c.LocationsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load locations file:\n%w", err)
+	}
+	location.Org = creds.Org
 
-	err = wait.ExponentialBackoff(c.Backoff,
+	client := &Client{
+		cloudDirector: govcd.NewVCDClient(*u, creds.Insecure),
+		url:           creds.URL,
+		location:      location,
+		downloadDir:   c.DownloadDir,
+		credentials:   creds,
+		backoff:       c.Backoff,
+	}
+
+	if err := client.authenticate(ctx); err != nil {
+		return nil, fmt.Errorf("failed to create Cloud Director client: %w", err)
+	}
+
+	return client, nil
+}
+
+// authenticate logs in to Cloud Director, retrying with backoff, and records
+// the time of the successful login so ensureSession can tell when a refresh
+// is due.
+func (c *Client) authenticate(ctx context.Context) error {
+	log := log.FromContext(ctx)
+
+	var lastErr error
+	err := wait.ExponentialBackoff(c.backoff,
 		func() (done bool, err error) {
-			lastErr = vcdClient.Authenticate(creds.Username, creds.Password, creds.Org)
+			lastErr = c.cloudDirector.Authenticate(c.credentials.Username, c.credentials.Password, c.credentials.Org)
 
 			// Return if client was successfully created, otherwise retry
 			if lastErr == nil {
@@ -77,25 +113,27 @@ func New(c Config, ctx context.Context) (*Client, error) {
 			log.Info("Retrying authentication to VCD")
 			return false, nil
 		})
-
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Cloud Director client: %w", lastErr)
+		return lastErr
 	}
 
-	log.Info("Successfully authenticated to Cloud Director", "vcdURL", creds.URL)
+	c.authenticatedAt = time.Now()
+	log.Info("Successfully authenticated to Cloud Director", "vcdURL", c.url)
+	return nil
+}
 
-	location, err := loadLocation(c.LocationsFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load locations file:\n%w", err)
+// ensureSession re-authenticates with Cloud Director if the current session
+// is old enough that it may have expired, so callers never have to deal with
+// a stale session themselves.
+func (c *Client) ensureSession(ctx context.Context) error {
+	if time.Since(c.authenticatedAt) < sessionRefreshThreshold {
+		return nil
 	}
 
-	location.Org = creds.Org
-	return &Client{
-		cloudDirector: vcdClient,
-		url:           creds.URL,
-		location:      location,
-		downloadDir:   c.DownloadDir,
-	}, nil
+	if err := c.authenticate(ctx); err != nil {
+		return fmt.Errorf("failed to refresh Cloud Director session: %w", err)
+	}
+	return nil
 }
 
 // GetLocations returns all configured cloudDirector locations
@@ -109,7 +147,7 @@ func (c *Client) GetLocations() map[string]interface{} {
 func (c *Client) Exists(ctx context.Context, name string, loc string) (bool, error) {
 	log := log.FromContext(ctx)
 
-	catalog, err := c.getCatalog()
+	catalog, err := c.getCatalog(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -132,7 +170,7 @@ func (c *Client) Exists(ctx context.Context, name string, loc string) (bool, err
 func (c *Client) Delete(ctx context.Context, name string, loc string) error {
 	log := log.FromContext(ctx)
 
-	catalog, err := c.getCatalog()
+	catalog, err := c.getCatalog(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get catalog: %w", err)
 	}
@@ -168,7 +206,7 @@ func (c *Client) Create(ctx context.Context, imageURL string, imageName string, 
 	log := log.FromContext(ctx)
 
 	// Get the catalog where we'll upload
-	catalog, err := c.getCatalog()
+	catalog, err := c.getCatalog(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get catalog: %w", err)
 	}
@@ -193,9 +231,21 @@ func (c *Client) Create(ctx context.Context, imageURL string, imageName string, 
 	return nil
 }
 
-// getOrg returns the organization object
-func (c *Client) getOrg() (*govcd.Org, error) {
+// getOrg returns the organization object. go-vcloud-director reports an
+// expired session as ErrorEntityNotFound here - indistinguishable from the
+// org actually being missing - so on that specific error it forces a
+// re-authentication and retries once before giving up.
+func (c *Client) getOrg(ctx context.Context) (*govcd.Org, error) {
+	if err := c.ensureSession(ctx); err != nil {
+		return nil, err
+	}
+
 	org, err := c.cloudDirector.GetOrgByName(c.location.Org)
+	if errors.Is(err, govcd.ErrorEntityNotFound) {
+		if reauthErr := c.authenticate(ctx); reauthErr == nil {
+			org, err = c.cloudDirector.GetOrgByName(c.location.Org)
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get organization %s: %w", c.location.Org, err)
 	}
@@ -203,8 +253,8 @@ func (c *Client) getOrg() (*govcd.Org, error) {
 }
 
 // getCatalog returns the catalog object
-func (c *Client) getCatalog() (*govcd.Catalog, error) {
-	org, err := c.getOrg()
+func (c *Client) getCatalog(ctx context.Context) (*govcd.Catalog, error) {
+	org, err := c.getOrg(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/36862

it appears that vcd sessions expire after 24h
this adds a session refresh after time x and also a refresh attempt on failure

### What does this PR do?

(Please set a descriptive PR title. Use this space for additional explanations.)

### What is the effect of this change to users?

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [ ] CHANGELOG.md has been updated (if it exists)
