### PR TITLE
feat: add local integration tests for vSphere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add local integration tests for the vSphere provider.
+
 ## [0.13.0] - 2026-07-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+## Codebase Overview
+
+`image-distribution-operator` is a Giant Swarm Kubernetes operator that syncs VM node OS images across infrastructure providers (vSphere, VMware Cloud Director, Proxmox). It watches external `Release` CRs, derives `NodeImage` CRs (its own CRD), and imports images from S3 into each provider's catalog via a pluggable `Provider` interface.
+
+**Stack**: Go 1.26.3, controller-runtime/kubebuilder (multigroup), Ginkgo/Gomega tests, Helm chart distribution, govmomi (vSphere) / go-vcloud-director (VCD) / hand-rolled REST client (Proxmox).
+
+**Structure**: `cmd/main.go` wires the manager; `internal/controller/{image,release}` hold the two reconcilers; `pkg/provider` defines the provider abstraction implemented by `pkg/{vsphere,cloud-director,proxmox}`; `pkg/image` and `pkg/s3` hold naming/CRUD and S3 helpers; `config/` is the kubebuilder scaffold (dev source of truth) which is mechanically synced into the production `helm/image-distribution-operator` chart via `sync/sync.sh`.
+
+For detailed architecture, module guide, data flow, conventions, and gotchas, see [docs/CODEBASE_MAP.md](docs/CODEBASE_MAP.md).

--- a/Makefile.integration.mk
+++ b/Makefile.integration.mk
@@ -1,0 +1,25 @@
+# Integration test harness (hand-maintained; picked up via `include Makefile.*.mk`).
+#
+# Stands up an in-process test environment - a real Kubernetes API server (envtest),
+# an in-process S3-compatible bucket, and an in-process vSphere API (vcsim) - and runs
+# the NodeImage controller against it. No Docker daemon is required.
+
+LOCALBIN            ?= $(shell pwd)/bin
+ENVTEST             ?= $(LOCALBIN)/setup-envtest
+ENVTEST_VERSION     ?= release-0.24
+ENVTEST_K8S_VERSION ?= 1.33.0
+
+##@ Integration testing
+
+.PHONY: setup-envtest
+setup-envtest: ## Downloads the envtest control-plane binaries (kube-apiserver, etcd) into bin/k8s.
+	@echo "====> $@"
+	@mkdir -p $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
+	$(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN)/k8s -p path
+
+.PHONY: test-integration
+test-integration: setup-envtest ## Runs the in-process integration suite (envtest + vcsim + fake S3).
+	@echo "====> $@"
+	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN)/k8s -p path)" \
+		go test -tags=integration ./test/integration/... -v -timeout 300s

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -1,0 +1,30 @@
+# Integration testing
+
+The integration suite (`test/integration/nodeimage_vsphere/`) exercises the real
+`NodeImageReconciler` end to end against in-process fakes — no Docker daemon required:
+
+- **envtest** — a real Kubernetes API server + etcd with the `NodeImage` CRD installed.
+- **vcsim** — govmomi's in-process vSphere simulator, standing in for a real vCenter.
+- **fake S3** — an in-process S3-compatible bucket (`gofakes3`) seeded with OVA fixtures.
+
+## What the tests cover
+
+Each spec creates a `NodeImage`, reconciles it, and asserts against vcsim's inventory:
+
+| Spec | Scenario | Expected outcome |
+|------|----------|------------------|
+| Import | Valid OVA seeded in S3 | Template imported into vSphere, status `Available` |
+| Delete | Imported image, then `NodeImage` deleted | Template destroyed, finalizer cleared, object gone |
+| Idempotency | Already-imported image re-reconciled | No re-import (template ref unchanged), stays `Available` |
+| Missing | S3 object absent | Reconcile requeues without error, status `Missing`, no template |
+| Error | S3 object present but not a valid OVA | Reconcile returns an error, status `Error`, no template |
+
+## Running
+
+```sh
+make test-integration
+```
+
+This first runs `make setup-envtest` to download the envtest control-plane binaries into
+`bin/k8s`, then runs the suite with the `integration` build tag. The tag keeps these tests
+out of the default `make test` / `go test ./...` run.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.30
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.105.1
 	github.com/giantswarm/releases/sdk v0.13.0
+	github.com/johannesboyne/gofakes3 v1.2.0
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/stretchr/testify v1.11.1
@@ -91,6 +92,7 @@ require (
 	github.com/prometheus/common v0.68.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
+	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -103,6 +105,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.shabbyrobe.org/gocovmerge v0.0.0-20230507111327-fa4f82cfbf4d // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.29 h1:WHZGssHH887cO0ox07SIQZsFx3M
 github.com/aws/aws-sdk-go-v2/credentials v1.19.29/go.mod h1:Mhl0xR6zjguiuj00XRx2wMx22sAltk7oya39sT7fdg8=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.30 h1:/hi1JADLEW9YYryEz1w4GQu0EtP23pP553Cf9KgsDV4=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.30/go.mod h1:/3AOgy4K17Dm4ucMZVC/MJkzy5kmfKUcINRHZyo0koQ=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.75 h1:S61/E3N01oral6B3y9hZ2E1iFDqCZPPOBoBQretCnBI=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.75/go.mod h1:bDMQbkI1vJbNjnvJYpPTSNYBkI/VIv18ngWb/K84tkk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 h1:xM/Is9cKMHa8Jj8zkvWhvrFkZsXJV9E+BB4g0HW0duQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30/go.mod h1:WueJeNDZvK1fMYEWJIkcivBfEzUkTpBhzlrUKKY8EuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 h1:jn46zC9LdsVR/ZpMIJqMqb8hHv31BlLx3ulVqNspUOk=
@@ -50,6 +52,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cevatbarisyilmaz/ara v0.0.4 h1:SGH10hXpBJhhTlObuZzTuFn1rrdmjQImITXnZVPSodc=
+github.com/cevatbarisyilmaz/ara v0.0.4/go.mod h1:BfFOxnUd6Mj6xmcvRxHN3Sr21Z1T3U2MYkYOmoQe4Ts=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -144,6 +148,8 @@ github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaX
 github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/johannesboyne/gofakes3 v1.2.0 h1:I9VEzPWvvAUAGzDlhYFoZjF0AXMlkcEyZlmBwiI6Oms=
+github.com/johannesboyne/gofakes3 v1.2.0/go.mod h1:UHhRZRod9rENGFrUWTYnQHZqlNgSmjOq8DaD/ATQYRM=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -194,7 +200,11 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 h1:GHRpF1pTW19a8tTFrMLUcfWwyC0pnifVo2ClaLq+hP8=
+github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46/go.mod h1:uAQ5PCi+MFsC7HjREoAz1BU+Mq60+05gifQSsHSDG/8=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
+github.com/spf13/afero v1.2.1 h1:qgMbHoJbPbw579P+1zVY+6n4nIFuIchaIjzZ/I/Yq8M=
+github.com/spf13/afero v1.2.1/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -221,6 +231,8 @@ github.com/vmware/govmomi v0.55.1 h1:7FW6VXIdKe/7AXftBoFTHaf0UO8Kdl84tIjothNDlZI
 github.com/vmware/govmomi v0.55.1/go.mod h1:QR6UoTHdmvT5XvdomNKwyi7VPOnrE0QZxjPBJ0mWWQs=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
+go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4vSTOOsNrsI4Ljf6C+6UKvpTEH5XY3JMoyPoo=
@@ -241,6 +253,8 @@ go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.shabbyrobe.org/gocovmerge v0.0.0-20230507111327-fa4f82cfbf4d h1:Ns9kd1Rwzw7t0BR8XMphenji4SmIoNZPn8zhYmaVKP8=
+go.shabbyrobe.org/gocovmerge v0.0.0-20230507111327-fa4f82cfbf4d/go.mod h1:92Uoe3l++MlthCm+koNi0tcUCX3anayogF0Pa/sp24k=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
@@ -290,6 +304,8 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce h1:xcEWjVhvbDy+nHP67nPDDpbYrY+ILlfndk4bRioVHaU=
+gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/integration/nodeimage_vsphere/nodeimage_test.go
+++ b/test/integration/nodeimage_vsphere/nodeimage_test.go
@@ -124,6 +124,138 @@ var _ = Describe("NodeImage vSphere reconciliation", func() {
 		err = k8sClient.Get(ctx, namespacedName, &imagev1alpha1.NodeImage{})
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
+
+	It("does not re-import when the template already exists", func() {
+		namespacedName := types.NamespacedName{Name: testIdempotentResourceName, Namespace: "default"}
+		templatePath := testutil.VCSimFolder + "/" + testIdempotentImageName
+
+		By("creating and importing the NodeImage")
+		nodeImage := &imagev1alpha1.NodeImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testIdempotentResourceName,
+				Namespace: "default",
+			},
+			Spec: imagev1alpha1.NodeImageSpec{
+				Name:     testIdempotentImageName,
+				Provider: testProvider,
+			},
+		}
+		Expect(k8sClient.Create(ctx, nodeImage)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, nodeImage)
+		})
+
+		nodeImage.Status.Releases = []string{"vsphere-1.2.3"}
+		nodeImage.Status.State = imagev1alpha1.NodeImagePending
+		Expect(k8sClient.Status().Update(ctx, nodeImage)).To(Succeed())
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("recording the imported template's managed object reference")
+		finder := vsphereFinder()
+		vm, err := finder.VirtualMachine(ctx, templatePath)
+		Expect(err).NotTo(HaveOccurred())
+		originalRef := vm.Reference()
+
+		By("reconciling a second time")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("confirming the template was not re-imported")
+		// A re-import would destroy/replace the VM and yield a new reference;
+		// an unchanged reference proves Exists() short-circuited the upload.
+		vm, err = finder.VirtualMachine(ctx, templatePath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vm.Reference()).To(Equal(originalRef))
+
+		By("confirming the NodeImage is still Available")
+		reconciled := &imagev1alpha1.NodeImage{}
+		Expect(k8sClient.Get(ctx, namespacedName, reconciled)).To(Succeed())
+		Expect(reconciled.Status.State).To(Equal(imagev1alpha1.NodeImageAvailable))
+	})
+
+	It("marks the NodeImage as Missing when the S3 object is absent", func() {
+		namespacedName := types.NamespacedName{Name: testMissingResourceName, Namespace: "default"}
+		templatePath := testutil.VCSimFolder + "/" + testMissingImageName
+
+		By("creating the NodeImage for an unseeded image")
+		nodeImage := &imagev1alpha1.NodeImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testMissingResourceName,
+				Namespace: "default",
+			},
+			Spec: imagev1alpha1.NodeImageSpec{
+				Name:     testMissingImageName,
+				Provider: testProvider,
+			},
+		}
+		Expect(k8sClient.Create(ctx, nodeImage)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, nodeImage)
+		})
+
+		nodeImage.Status.Releases = []string{"vsphere-1.2.3"}
+		nodeImage.Status.State = imagev1alpha1.NodeImagePending
+		Expect(k8sClient.Status().Update(ctx, nodeImage)).To(Succeed())
+
+		By("reconciling the NodeImage")
+		// The HEAD check against the fake bucket 404s, so the reconcile requeues
+		// without error rather than propagating a failure.
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("observing the NodeImage reported as Missing")
+		reconciled := &imagev1alpha1.NodeImage{}
+		Expect(k8sClient.Get(ctx, namespacedName, reconciled)).To(Succeed())
+		Expect(reconciled.Status.State).To(Equal(imagev1alpha1.NodeImageMissing))
+
+		By("confirming no template was imported into vSphere")
+		finder := vsphereFinder()
+		_, err = finder.VirtualMachine(ctx, templatePath)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("marks the NodeImage as Error when the OVA import fails", func() {
+		namespacedName := types.NamespacedName{Name: testErrorResourceName, Namespace: "default"}
+		templatePath := testutil.VCSimFolder + "/" + testErrorImageName
+
+		By("creating the NodeImage for an image seeded with garbage bytes")
+		nodeImage := &imagev1alpha1.NodeImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testErrorResourceName,
+				Namespace: "default",
+			},
+			Spec: imagev1alpha1.NodeImageSpec{
+				Name:     testErrorImageName,
+				Provider: testProvider,
+			},
+		}
+		Expect(k8sClient.Create(ctx, nodeImage)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, nodeImage)
+		})
+
+		nodeImage.Status.Releases = []string{"vsphere-1.2.3"}
+		nodeImage.Status.State = imagev1alpha1.NodeImagePending
+		Expect(k8sClient.Status().Update(ctx, nodeImage)).To(Succeed())
+
+		By("reconciling the NodeImage")
+		// The object exists (HEAD 200) but is not a valid OVA, so the import
+		// fails and the reconcile propagates the error after setting the status.
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
+		Expect(err).To(HaveOccurred())
+
+		By("observing the NodeImage reported as Error")
+		reconciled := &imagev1alpha1.NodeImage{}
+		Expect(k8sClient.Get(ctx, namespacedName, reconciled)).To(Succeed())
+		Expect(reconciled.Status.State).To(Equal(imagev1alpha1.NodeImageError))
+
+		By("confirming no template was imported into vSphere")
+		finder := vsphereFinder()
+		_, err = finder.VirtualMachine(ctx, templatePath)
+		Expect(err).To(HaveOccurred())
+	})
 })
 
 // vsphereFinder returns a govmomi finder scoped to the simulator's datacenter,

--- a/test/integration/nodeimage_vsphere/nodeimage_test.go
+++ b/test/integration/nodeimage_vsphere/nodeimage_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/vim25/mo"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -67,14 +68,7 @@ var _ = Describe("NodeImage vSphere reconciliation", func() {
 		Expect(reconciled.Status.State).To(Equal(imagev1alpha1.NodeImageAvailable))
 
 		By("confirming the image was imported into vSphere as a template")
-		gclient, err := vcsim.Client(ctx)
-		Expect(err).NotTo(HaveOccurred())
-
-		finder := find.NewFinder(gclient.Client, true)
-		dc, err := finder.DatacenterOrDefault(ctx, testutil.VCSimDatacenter)
-		Expect(err).NotTo(HaveOccurred())
-		finder.SetDatacenter(dc)
-
+		finder := vsphereFinder()
 		vm, err := finder.VirtualMachine(ctx, testutil.VCSimFolder+"/"+testImageName)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -83,4 +77,65 @@ var _ = Describe("NodeImage vSphere reconciliation", func() {
 		Expect(managedVM.Config).NotTo(BeNil())
 		Expect(managedVM.Config.Template).To(BeTrue())
 	})
+
+	It("destroys the vSphere template when the NodeImage is deleted", func() {
+		namespacedName := types.NamespacedName{Name: testDeleteResourceName, Namespace: "default"}
+		templatePath := testutil.VCSimFolder + "/" + testDeleteImageName
+
+		By("creating and importing the NodeImage")
+		nodeImage := &imagev1alpha1.NodeImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testDeleteResourceName,
+				Namespace: "default",
+			},
+			Spec: imagev1alpha1.NodeImageSpec{
+				Name:     testDeleteImageName,
+				Provider: testProvider,
+			},
+		}
+		Expect(k8sClient.Create(ctx, nodeImage)).To(Succeed())
+
+		nodeImage.Status.Releases = []string{"vsphere-1.2.3"}
+		nodeImage.Status.State = imagev1alpha1.NodeImagePending
+		Expect(k8sClient.Status().Update(ctx, nodeImage)).To(Succeed())
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("confirming the template exists before deletion")
+		finder := vsphereFinder()
+		_, err = finder.VirtualMachine(ctx, templatePath)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("deleting the NodeImage")
+		// The finalizer added during the create reconcile keeps the object alive
+		// (deletion timestamp set) until the deletion reconcile runs.
+		Expect(k8sClient.Delete(ctx, nodeImage)).To(Succeed())
+
+		By("reconciling the deletion")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("confirming the template was destroyed in vSphere")
+		_, err = finder.VirtualMachine(ctx, templatePath)
+		Expect(err).To(HaveOccurred())
+
+		By("confirming the NodeImage was removed once the finalizer cleared")
+		err = k8sClient.Get(ctx, namespacedName, &imagev1alpha1.NodeImage{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
 })
+
+// vsphereFinder returns a govmomi finder scoped to the simulator's datacenter,
+// used to assert on inventory state independently of the code under test.
+func vsphereFinder() *find.Finder {
+	gclient, err := vcsim.Client(ctx)
+	Expect(err).NotTo(HaveOccurred())
+
+	finder := find.NewFinder(gclient.Client, true)
+	dc, err := finder.DatacenterOrDefault(ctx, testutil.VCSimDatacenter)
+	Expect(err).NotTo(HaveOccurred())
+	finder.SetDatacenter(dc)
+
+	return finder
+}

--- a/test/integration/nodeimage_vsphere/nodeimage_test.go
+++ b/test/integration/nodeimage_vsphere/nodeimage_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeimagevsphere
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/vim25/mo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	imagev1alpha1 "github.com/giantswarm/image-distribution-operator/api/image/v1alpha1"
+	"github.com/giantswarm/image-distribution-operator/test/integration/testutil"
+)
+
+var _ = Describe("NodeImage vSphere reconciliation", func() {
+	It("imports the S3 image into vSphere as a template", func() {
+		namespacedName := types.NamespacedName{Name: testResourceName, Namespace: "default"}
+
+		By("creating the NodeImage resource")
+		nodeImage := &imagev1alpha1.NodeImage{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testResourceName,
+				Namespace: "default",
+			},
+			Spec: imagev1alpha1.NodeImageSpec{
+				Name:     testImageName,
+				Provider: testProvider,
+			},
+		}
+		Expect(k8sClient.Create(ctx, nodeImage)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, nodeImage)
+		})
+
+		By("seeding status.releases (normally populated by the release controller)")
+		nodeImage.Status.Releases = []string{"vsphere-1.2.3"}
+		nodeImage.Status.State = imagev1alpha1.NodeImagePending
+		Expect(k8sClient.Status().Update(ctx, nodeImage)).To(Succeed())
+
+		By("reconciling the NodeImage")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("observing the NodeImage reported as Available")
+		reconciled := &imagev1alpha1.NodeImage{}
+		Expect(k8sClient.Get(ctx, namespacedName, reconciled)).To(Succeed())
+		Expect(reconciled.Status.State).To(Equal(imagev1alpha1.NodeImageAvailable))
+
+		By("confirming the image was imported into vSphere as a template")
+		gclient, err := vcsim.Client(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		finder := find.NewFinder(gclient.Client, true)
+		dc, err := finder.DatacenterOrDefault(ctx, testutil.VCSimDatacenter)
+		Expect(err).NotTo(HaveOccurred())
+		finder.SetDatacenter(dc)
+
+		vm, err := finder.VirtualMachine(ctx, testutil.VCSimFolder+"/"+testImageName)
+		Expect(err).NotTo(HaveOccurred())
+
+		var managedVM mo.VirtualMachine
+		Expect(vm.Properties(ctx, vm.Reference(), []string{"config.template"}, &managedVM)).To(Succeed())
+		Expect(managedVM.Config).NotTo(BeNil())
+		Expect(managedVM.Config.Template).To(BeTrue())
+	})
+})

--- a/test/integration/nodeimage_vsphere/suite_test.go
+++ b/test/integration/nodeimage_vsphere/suite_test.go
@@ -52,6 +52,11 @@ const (
 	// testImageName is the value placed in NodeImage.Spec.Name. pkg/image derives
 	// the S3 object key (and thus the fixture we seed) from it.
 	testImageName = "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs"
+
+	// The deletion test uses a distinct resource/image so it imports and destroys
+	// its own vcsim template, independent of the create test's inventory.
+	testDeleteResourceName = "vsphere-test-image-delete"
+	testDeleteImageName    = "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-delete-gs"
 )
 
 var (
@@ -115,6 +120,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	fakeS3, err = testutil.StartFakeS3(imageKey, ova)
 	Expect(err).NotTo(HaveOccurred())
+
+	deleteImageKey := imagekey.GetImageKey(&imagev1alpha1.NodeImage{
+		Spec: imagev1alpha1.NodeImageSpec{Name: testDeleteImageName, Provider: testProvider},
+	})
+	Expect(fakeS3.Seed(deleteImageKey, ova)).To(Succeed())
 
 	// Must run before constructing the vSphere client: govmomi's soap client
 	// inherits DialContext from http.DefaultTransport at construction time.

--- a/test/integration/nodeimage_vsphere/suite_test.go
+++ b/test/integration/nodeimage_vsphere/suite_test.go
@@ -57,6 +57,21 @@ const (
 	// its own vcsim template, independent of the create test's inventory.
 	testDeleteResourceName = "vsphere-test-image-delete"
 	testDeleteImageName    = "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-delete-gs"
+
+	// Ginkgo randomizes spec order, so every spec below owns a distinct
+	// resource/image name to keep its vcsim inventory independent.
+
+	// Idempotency test: valid OVA seeded, imported then re-reconciled.
+	testIdempotentResourceName = "vsphere-test-image-idempotent"
+	testIdempotentImageName    = "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-idempotent-gs"
+
+	// Missing test: deliberately NOT seeded into the fake bucket.
+	testMissingResourceName = "vsphere-test-image-missing"
+	testMissingImageName    = "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-missing-gs"
+
+	// Error test: seeded with garbage bytes so the OVF import fails.
+	testErrorResourceName = "vsphere-test-image-error"
+	testErrorImageName    = "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-error-gs"
 )
 
 var (
@@ -125,6 +140,19 @@ var _ = BeforeSuite(func() {
 		Spec: imagev1alpha1.NodeImageSpec{Name: testDeleteImageName, Provider: testProvider},
 	})
 	Expect(fakeS3.Seed(deleteImageKey, ova)).To(Succeed())
+
+	idempotentImageKey := imagekey.GetImageKey(&imagev1alpha1.NodeImage{
+		Spec: imagev1alpha1.NodeImageSpec{Name: testIdempotentImageName, Provider: testProvider},
+	})
+	Expect(fakeS3.Seed(idempotentImageKey, ova)).To(Succeed())
+
+	// Seeded with bytes that are not a valid OVA so the vSphere import fails.
+	errorImageKey := imagekey.GetImageKey(&imagev1alpha1.NodeImage{
+		Spec: imagev1alpha1.NodeImageSpec{Name: testErrorImageName, Provider: testProvider},
+	})
+	Expect(fakeS3.Seed(errorImageKey, []byte("not a valid ova"))).To(Succeed())
+
+	// testMissingImageName is intentionally left unseeded.
 
 	// Must run before constructing the vSphere client: govmomi's soap client
 	// inherits DialContext from http.DefaultTransport at construction time.

--- a/test/integration/nodeimage_vsphere/suite_test.go
+++ b/test/integration/nodeimage_vsphere/suite_test.go
@@ -1,0 +1,184 @@
+//go:build integration
+
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeimagevsphere
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	imagev1alpha1 "github.com/giantswarm/image-distribution-operator/api/image/v1alpha1"
+	imagectrl "github.com/giantswarm/image-distribution-operator/internal/controller/image"
+	imagekey "github.com/giantswarm/image-distribution-operator/pkg/image"
+	"github.com/giantswarm/image-distribution-operator/pkg/provider"
+	"github.com/giantswarm/image-distribution-operator/pkg/s3"
+	"github.com/giantswarm/image-distribution-operator/pkg/vsphere"
+	"github.com/giantswarm/image-distribution-operator/test/integration/testutil"
+	"github.com/giantswarm/image-distribution-operator/test/utils"
+)
+
+const (
+	testProvider     = "vsphere"
+	testResourceName = "vsphere-test-image"
+	// testImageName is the value placed in NodeImage.Spec.Name. pkg/image derives
+	// the S3 object key (and thus the fixture we seed) from it.
+	testImageName = "flatcar-stable-3975.2.0-kube-1.30.4-tooling-1.18.1-gs"
+)
+
+var (
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+
+	vcsim         *testutil.VCSim
+	fakeS3        *testutil.FakeS3
+	restoreS3     func()
+	tempDir       string
+	reconciler    *imagectrl.NodeImageReconciler
+	vsphereClient *vsphere.Client
+)
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NodeImage vSphere Integration Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	Expect(imagev1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	By("bootstrapping the test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	utils.GetEnvOrSkip("KUBEBUILDER_ASSETS")
+
+	if dir := firstFoundEnvTestBinaryDir(); dir != "" {
+		testEnv.BinaryAssetsDirectory = dir
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	By("starting the in-process vSphere simulator")
+	vcsim, err = testutil.StartVCSim()
+	Expect(err).NotTo(HaveOccurred())
+
+	By("seeding the in-process S3 bucket with an OVA fixture")
+	imageKey := imagekey.GetImageKey(&imagev1alpha1.NodeImage{
+		Spec: imagev1alpha1.NodeImageSpec{Name: testImageName, Provider: testProvider},
+	})
+	ova, err := testutil.BuildOVA()
+	Expect(err).NotTo(HaveOccurred())
+	fakeS3, err = testutil.StartFakeS3(imageKey, ova)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Must run before constructing the vSphere client: govmomi's soap client
+	// inherits DialContext from http.DefaultTransport at construction time.
+	restoreS3 = testutil.RedirectS3Transport(fakeS3)
+
+	By("constructing the real vSphere provider and S3 client")
+	tempDir, err = os.MkdirTemp("", "idop-integration-")
+	Expect(err).NotTo(HaveOccurred())
+	credentialsPath, locationsPath, err := vcsim.WriteConfig(tempDir)
+	Expect(err).NotTo(HaveOccurred())
+
+	vsphereClient, err = vsphere.New(vsphere.Config{
+		Backoff:         wait.Backoff{Steps: 5, Duration: 100 * time.Millisecond, Factor: 1.0},
+		CredentialsFile: credentialsPath,
+		LocationsFile:   locationsPath,
+		PullMode:        false,
+	}, ctx)
+	Expect(err).NotTo(HaveOccurred())
+
+	s3Client, err := s3.New(s3.Config{
+		HTTP:       true,
+		BucketName: testutil.S3Bucket,
+		Region:     testutil.S3Region,
+		Timeout:    30 * time.Second,
+	}, ctx)
+	Expect(err).NotTo(HaveOccurred())
+
+	reconciler = &imagectrl.NodeImageReconciler{
+		Client:    k8sClient,
+		S3Client:  s3Client,
+		Providers: map[string]provider.Provider{testProvider: vsphereClient},
+	}
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	if restoreS3 != nil {
+		restoreS3()
+	}
+	if fakeS3 != nil {
+		fakeS3.Close()
+	}
+	if vcsim != nil {
+		vcsim.Close()
+	}
+	if tempDir != "" {
+		Expect(os.RemoveAll(tempDir)).To(Succeed())
+	}
+	cancel()
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+// firstFoundEnvTestBinaryDir mirrors the helper in the controller suites so the
+// test can also be run from an IDE after `make setup-envtest`.
+func firstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}

--- a/test/integration/testutil/ova.go
+++ b/test/integration/testutil/ova.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package testutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+)
+
+// diskFileName is the disk referenced by the OVF descriptor and must match the
+// tar entry written into the archive.
+const diskFileName = "flatcar-disk1.vmdk"
+
+// ovfDescriptor is a minimal-but-structurally-valid OVF envelope. It is derived
+// from govmomi's own ttylinux test fixture, trimmed to the smallest shape that
+// govmomi's importer can parse and that vcsim's OvfManager accepts. The single
+// network is named "nic0" so it lines up with the NetworkMapping the vSphere
+// provider hard-codes (see pkg/vsphere/import.go).
+var ovfDescriptor = fmt.Sprintf(`<Envelope
+    xmlns="http://schemas.dmtf.org/ovf/envelope/1"
+    xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1"
+    xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData"
+    xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
+  <References>
+    <File ovf:href="%s" ovf:id="file1" ovf:size="1024"/>
+  </References>
+  <DiskSection>
+    <Info>Virtual disk information</Info>
+    <Disk ovf:capacity="1" ovf:capacityAllocationUnits="byte * 2^20" ovf:diskId="vmdisk1" ovf:fileRef="file1"
+          ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
+  </DiskSection>
+  <NetworkSection>
+    <Info>The list of logical networks</Info>
+    <Network ovf:name="nic0">
+      <Description>The nic0 network</Description>
+    </Network>
+  </NetworkSection>
+  <VirtualSystem ovf:id="vm">
+    <Info>A virtual machine</Info>
+    <Name>flatcar</Name>
+    <OperatingSystemSection ovf:id="36">
+      <Info>The kind of installed guest operating system</Info>
+    </OperatingSystemSection>
+    <VirtualHardwareSection>
+      <Info>Virtual hardware requirements</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemIdentifier>flatcar</vssd:VirtualSystemIdentifier>
+        <vssd:VirtualSystemType>vmx-09</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:Description>Number of Virtual CPUs</rasd:Description>
+        <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>32MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>32</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>IDE Controller</rasd:Description>
+        <rasd:ElementName>ideController0</rasd:ElementName>
+        <rasd:InstanceID>3</rasd:InstanceID>
+        <rasd:ResourceType>5</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>disk0</rasd:ElementName>
+        <rasd:HostResource>ovf:/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:Parent>3</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>1</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Connection>nic0</rasd:Connection>
+        <rasd:ElementName>ethernet0</rasd:ElementName>
+        <rasd:InstanceID>5</rasd:InstanceID>
+        <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+      </Item>
+    </VirtualHardwareSection>
+  </VirtualSystem>
+</Envelope>`, diskFileName)
+
+// BuildOVA returns an OVA (uncompressed tar) containing the OVF descriptor and a
+// small dummy disk. It only needs to "look and behave like" an image: govmomi
+// parses the descriptor and streams the disk bytes to vcsim over an NFC lease -
+// the disk contents themselves are never inspected.
+func BuildOVA() ([]byte, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	entries := []struct {
+		name string
+		data []byte
+	}{
+		{name: "flatcar.ovf", data: []byte(ovfDescriptor)},
+		{name: diskFileName, data: bytes.Repeat([]byte{0}, 1024)},
+	}
+
+	for _, e := range entries {
+		hdr := &tar.Header{Name: e.name, Mode: 0o644, Size: int64(len(e.data))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, fmt.Errorf("failed to write tar header for %s: %w", e.name, err)
+		}
+		if _, err := tw.Write(e.data); err != nil {
+			return nil, fmt.Errorf("failed to write tar entry %s: %w", e.name, err)
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close tar writer: %w", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/test/integration/testutil/s3.go
+++ b/test/integration/testutil/s3.go
@@ -27,9 +27,10 @@ func s3VirtualHost() string {
 	return fmt.Sprintf("%s.s3.%s.amazonaws.com", S3Bucket, S3Region)
 }
 
-// FakeS3 is an in-process S3-compatible server seeded with a single object.
+// FakeS3 is an in-process S3-compatible server seeded with one or more objects.
 type FakeS3 struct {
-	server *httptest.Server
+	backend gofakes3.Backend
+	server  *httptest.Server
 }
 
 // StartFakeS3 boots gofakes3 configured for virtual-hosted-style addressing and
@@ -42,7 +43,21 @@ func StartFakeS3(objectKey string, object []byte) (*FakeS3, error) {
 	if err := backend.CreateBucket(S3Bucket); err != nil {
 		return nil, fmt.Errorf("failed to create fake bucket: %w", err)
 	}
-	if _, err := backend.PutObject(
+
+	f := &FakeS3{
+		backend: backend,
+		server:  httptest.NewServer(faker.Server()),
+	}
+	if err := f.Seed(objectKey, object); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// Seed adds another object to the bucket, letting a suite serve fixtures for
+// more than one image key from the same fake server.
+func (f *FakeS3) Seed(objectKey string, object []byte) error {
+	if _, err := f.backend.PutObject(
 		S3Bucket,
 		objectKey,
 		map[string]string{"Content-Type": "application/octet-stream"},
@@ -50,10 +65,9 @@ func StartFakeS3(objectKey string, object []byte) (*FakeS3, error) {
 		int64(len(object)),
 		nil,
 	); err != nil {
-		return nil, fmt.Errorf("failed to seed fake object %s: %w", objectKey, err)
+		return fmt.Errorf("failed to seed fake object %s: %w", objectKey, err)
 	}
-
-	return &FakeS3{server: httptest.NewServer(faker.Server())}, nil
+	return nil
 }
 
 // Close shuts down the fake server.

--- a/test/integration/testutil/s3.go
+++ b/test/integration/testutil/s3.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package testutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/johannesboyne/gofakes3"
+	"github.com/johannesboyne/gofakes3/backend/s3mem"
+)
+
+// These match the s3.Config the suite constructs; pkg/s3.GetURL derives the
+// virtual-hosted hostname (<bucket>.s3.<region>.amazonaws.com) from them.
+const (
+	S3Bucket = "test-bucket"
+	S3Region = "us-east-1"
+)
+
+// s3VirtualHost is the hostname pkg/s3 builds for objects in the bucket. Both
+// the reconciler's HEAD check and the vSphere OVA download target this host.
+func s3VirtualHost() string {
+	return fmt.Sprintf("%s.s3.%s.amazonaws.com", S3Bucket, S3Region)
+}
+
+// FakeS3 is an in-process S3-compatible server seeded with a single object.
+type FakeS3 struct {
+	server *httptest.Server
+}
+
+// StartFakeS3 boots gofakes3 configured for virtual-hosted-style addressing and
+// seeds the bucket with object at objectKey. gofakes3 rewrites requests whose
+// Host is a subdomain of the base into path-style bucket routing.
+func StartFakeS3(objectKey string, object []byte) (*FakeS3, error) {
+	backend := s3mem.New()
+	faker := gofakes3.New(backend, gofakes3.WithHostBucketBase(fmt.Sprintf("s3.%s.amazonaws.com", S3Region)))
+
+	if err := backend.CreateBucket(S3Bucket); err != nil {
+		return nil, fmt.Errorf("failed to create fake bucket: %w", err)
+	}
+	if _, err := backend.PutObject(
+		S3Bucket,
+		objectKey,
+		map[string]string{"Content-Type": "application/octet-stream"},
+		bytes.NewReader(object),
+		int64(len(object)),
+		nil,
+	); err != nil {
+		return nil, fmt.Errorf("failed to seed fake object %s: %w", objectKey, err)
+	}
+
+	return &FakeS3{server: httptest.NewServer(faker.Server())}, nil
+}
+
+// Close shuts down the fake server.
+func (f *FakeS3) Close() {
+	f.server.Close()
+}
+
+// RedirectS3Transport rewrites http.DefaultTransport so that any connection to
+// the virtual-hosted S3 endpoint is dialed against the fake server instead,
+// regardless of the (unspecified, i.e. :80/:443) port in the URL. This is what
+// lets us keep pkg/s3.GetURL's hard-coded amazonaws.com hostname unchanged.
+//
+// It must be called BEFORE constructing the vSphere client: govmomi's soap
+// client copies DialContext from http.DefaultTransport at construction time, so
+// this patch is what routes its OVA download to the fake bucket. The reconciler's
+// http.Head check uses http.DefaultClient and picks it up at request time.
+//
+// The returned function restores the original transport.
+func RedirectS3Transport(f *FakeS3) func() {
+	original := http.DefaultTransport
+	patched := original.(*http.Transport).Clone()
+
+	target := f.server.Listener.Addr().String()
+	host := s3VirtualHost()
+	dialer := &net.Dialer{}
+
+	patched.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if h, _, err := net.SplitHostPort(addr); err == nil && h == host {
+			return dialer.DialContext(ctx, network, target)
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+
+	http.DefaultTransport = patched
+	return func() { http.DefaultTransport = original }
+}

--- a/test/integration/testutil/vcsim.go
+++ b/test/integration/testutil/vcsim.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/simulator"
+)
+
+// vcsim inventory names below match govmomi's default VPX model (see
+// simulator.VPX()). They are also written into the locations file consumed by
+// pkg/vsphere, and reused by the test to assert against the imported VM.
+const (
+	VCSimLocation   = "integration"
+	VCSimDatacenter = "DC0"
+	VCSimCluster    = "DC0_C0"
+	VCSimDatastore  = "LocalDS_0"
+	VCSimFolder     = "/DC0/vm"
+)
+
+// VCSim is an in-process vSphere API simulator serving over HTTPS.
+type VCSim struct {
+	model  *simulator.Model
+	server *simulator.Server
+}
+
+// StartVCSim boots the govmomi simulator with the default VPX inventory and TLS
+// enabled (pkg/vsphere always dials https://<vcenter>/sdk).
+func StartVCSim() (*VCSim, error) {
+	model := simulator.VPX()
+	if err := model.Create(); err != nil {
+		return nil, fmt.Errorf("failed to create vcsim model: %w", err)
+	}
+
+	// Serve over HTTPS: pkg/vsphere hard-codes the https scheme.
+	model.Service.TLS = new(tls.Config)
+	server := model.Service.NewServer()
+
+	return &VCSim{model: model, server: server}, nil
+}
+
+// Close tears down the simulator and removes its temporary state.
+func (v *VCSim) Close() {
+	v.server.Close()
+	v.model.Remove()
+}
+
+// Host returns the simulator's host:port, used as the "vcenter" credential.
+func (v *VCSim) Host() string {
+	return v.server.URL.Host
+}
+
+// WriteConfig writes the credentials and locations YAML files that pkg/vsphere
+// expects, wired to this simulator and its default inventory, and returns their
+// paths.
+func (v *VCSim) WriteConfig(dir string) (credentialsPath, locationsPath string, err error) {
+	credentials := fmt.Sprintf("vcenter: %s\nusername: user\npassword: pass\n", v.Host())
+	credentialsPath = filepath.Join(dir, "credentials.yaml")
+	if err := os.WriteFile(credentialsPath, []byte(credentials), 0o600); err != nil {
+		return "", "", fmt.Errorf("failed to write credentials file: %w", err)
+	}
+
+	locations := fmt.Sprintf(`%s:
+  datacenter: %s
+  datastore: %s
+  folder: %s
+  cluster: %s
+  resourcepool: Resources
+`, VCSimLocation, VCSimDatacenter, VCSimDatastore, VCSimFolder, VCSimCluster)
+	locationsPath = filepath.Join(dir, "locations.yaml")
+	if err := os.WriteFile(locationsPath, []byte(locations), 0o600); err != nil {
+		return "", "", fmt.Errorf("failed to write locations file: %w", err)
+	}
+
+	return credentialsPath, locationsPath, nil
+}
+
+// Client returns a govmomi client connected to the simulator, for asserting on
+// inventory state independently of the code under test.
+func (v *VCSim) Client(ctx context.Context) (*govmomi.Client, error) {
+	u := &url.URL{
+		Scheme: "https",
+		Host:   v.Host(),
+		Path:   "/sdk",
+		User:   url.UserPassword("user", "pass"),
+	}
+	return govmomi.NewClient(ctx, u, true)
+}


### PR DESCRIPTION
### What does this PR do?

Adds new test targets which can be run locally to test the controller against a mock vSphere API.

Running the `test-integration` make target does the following:

- stands up a kubernetes API server+etcd pair using `envtest`
- applies the CRDs to the kubernetes API
- runs a mock S3 endpoint which serves a minimal VMDK
- applies a NodeImage CR which references the VMDK
- runs a mock vSphere API which listens on the endpoints we need
- tests if the controller can upload the VMDK to the vSphere API
- tests if the controller can delete the VMDK when the NodeImage CR is deleted
- tests idempotency by reconciling a NodeImage which has already been uploaded to vSphere and ensures nothing changes
- tests what happens if the VMDK isn't in the S3 bucket
- tests how IDO behaves if it attempts to upload a corrupted VMDK 

### What is the effect of this change to users?

Nothing, aside from adding tests

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)

### Any background context you can provide?

Inspired by https://github.com/giantswarm/giantswarm/issues/

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
